### PR TITLE
rename sigin to login

### DIFF
--- a/agents/claude/CHANGELOG.md
+++ b/agents/claude/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.2.1
+
+Renames the manual `login` skill to `signin` for clearer intent. The underlying `zerogpu login` CLI subcommand is unchanged — only the skill's name and its slash invocation move from `/zerogpu-router:login` to `/zerogpu-router:signin`. Anyone scripting the old invocation must update it.
+
+### Changed
+
+- `skills/login/` → `skills/signin/` (directory renamed); `SKILL.md` `name:` field `login` → `signin`. The `zerogpu login` body command and `allowed-tools: Bash(zerogpu login*)` are untouched.
+- `agents/claude/README.md`: per-skill heading, synopsis, example, lookup-table row, and troubleshooting steps now reference `/zerogpu-router:signin`; the manual-only intro lists `signin`.
+- `agents/claude/COOKBOOK.md`, `skills/status/SKILL.md`: "not signed in" guidance now points to `/zerogpu-router:signin`.
+- `agents/claude/.claude-plugin/plugin.json`: version `1.2.0` → `1.2.1`.
+
+### Install
+
+```
+/plugin marketplace add zerogpu/zerogpu-router
+/plugin install zerogpu-router@zerogpu
+```
+
 ## 1.2.0
 
 Re-introduces the `summarize` skill, taking the surface from 12 to 13. It was dropped in 1.1.0 when its t5-small space was deprecated; it now runs on `llama-3.1-8b-instruct-fast`, which produces fuller, more coherent abstractive summaries than the old model.

--- a/agents/claude/README.md
+++ b/agents/claude/README.md
@@ -125,9 +125,9 @@ Call any skill explicitly with `/zerogpu-router:<name> <args>`:
 
 ## Skills in detail
 
-Each skill below documents what it does, which ZeroGPU model it runs, how to invoke it, what arguments it accepts, and what the output looks like. All inference skills auto-invoke when Claude detects a matching request; `login` and `status` are manual-only.
+Each skill below documents what it does, which ZeroGPU model it runs, how to invoke it, what arguments it accepts, and what the output looks like. All inference skills auto-invoke when Claude detects a matching request; `signin` and `status` are manual-only.
 
-### `/zerogpu-router:login`
+### `/zerogpu-router:signin`
 
 Sign in to ZeroGPU and persist your credentials so every subsequent skill call works without re-prompting.
 
@@ -137,7 +137,7 @@ Sign in to ZeroGPU and persist your credentials so every subsequent skill call w
 **Synopsis**
 
 ```
-/zerogpu-router:login [--api-key <key>] [--project-id <id>]
+/zerogpu-router:signin [--api-key <key>] [--project-id <id>]
 ```
 
 **Arguments**
@@ -150,7 +150,7 @@ Sign in to ZeroGPU and persist your credentials so every subsequent skill call w
 **Example**
 
 ```text
-/zerogpu-router:login
+/zerogpu-router:signin
 ```
 
 On success the API key + Project ID are written to your config file, and `ZEROGPU_API_KEY` is added to your shell profile so other tools can pick it up.
@@ -170,7 +170,7 @@ Show your current ZeroGPU sign-in status and the masked API key.
 /zerogpu-router:status
 ```
 
-Exit code is `0` when signed in, `1` when not. If you're not signed in, run `/zerogpu-router:login`.
+Exit code is `0` when signed in, `1` when not. If you're not signed in, run `/zerogpu-router:signin`.
 
 ---
 
@@ -555,7 +555,7 @@ Quick lookup table — all 13 skills at a glance.
 
 | Skill | Purpose | Example |
 | --- | --- | --- |
-| `/zerogpu-router:login` | Sign in and persist API key + Project ID (manual only) | `/zerogpu-router:login` |
+| `/zerogpu-router:signin` | Sign in and persist API key + Project ID (manual only) | `/zerogpu-router:signin` |
 | `/zerogpu-router:status` | Show current sign-in status (manual only) | `/zerogpu-router:status` |
 | `/zerogpu-router:chat <text>` | Short chat reply via `LFM2.5-1.2B-Instruct` | `/zerogpu-router:chat "Explain WebSockets in two sentences."` |
 | `/zerogpu-router:chat-thinking <text>` | Chat with the Thinking variant (returns reasoning) | `/zerogpu-router:chat-thinking "If a train leaves at 3 PM going 60 mph, when does it cover 150 miles?"` |
@@ -578,9 +578,9 @@ For full flag reference (thresholds, categories, schema syntax), run `zerogpu <c
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | `zerogpu: command not found` | CLI not installed or not on `PATH` | `npm install -g zerogpu-cli`, then restart your shell |
-| Skill returns "You're not signed in yet." | No credentials | Run `/zerogpu-router:login` |
+| Skill returns "You're not signed in yet." | No credentials | Run `/zerogpu-router:signin` |
 | `/zerogpu-router:*` skills don't appear in `/help` | Plugin not enabled | Run `/plugin` and enable `zerogpu-router` |
-| `Request failed with status 401` | Bad / revoked API key | Re-run `/zerogpu-router:login` |
+| `Request failed with status 401` | Bad / revoked API key | Re-run `/zerogpu-router:signin` |
 | `Request failed with status 429` | Rate limited | Back off and retry |
 
 ---

--- a/agents/claude/skills/signin/SKILL.md
+++ b/agents/claude/skills/signin/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: login
+name: signin
 description: Sign in to ZeroGPU and persist the API key + Project ID. Use when the user asks to log in, authenticate, or set up ZeroGPU credentials for the first time.
 argument-hint: "[--api-key <key>] [--project-id <id>]"
 disable-model-invocation: true

--- a/agents/claude/skills/status/SKILL.md
+++ b/agents/claude/skills/status/SKILL.md
@@ -11,4 +11,4 @@ Check the sign-in status:
 zerogpu status
 ```
 
-Exit code is `0` when signed in, `1` when not. If not signed in, suggest running `/zerogpu-router:login`.
+Exit code is `0` when signed in, `1` when not. If not signed in, suggest running `/zerogpu-router:signin`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed authentication command from `/zerogpu-router:login` to `/zerogpu-router:signin` in all documentation and skill references.
  * Updated troubleshooting guides and command examples to reflect the new signin command name.
  * Clarified credential setup flow in status check documentation.
  * Bumped Claude plugin version to 1.2.1 with updated installation instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zerogpu/zerogpu-router/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->