### PR TITLE
add cost savings skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ZeroGPU Router is a smart task router for AI agents. It exposes task-specific to
 Your agent keeps doing the heavy reasoning. The boring stuff gets routed to ZeroGPU.
 
 - **OpenClaw** — install **`zerogpu-openclaw-plugin`** and register MCP in OpenClaw (see [agents/openclaw/](agents/openclaw/)); package name and plugin `id` match.
-- **Claude Code** — no MCP setup. Install the `zerogpu` CLI plus the marketplace plugin and you get 13 auto-invoked skills (see [agents/claude/](agents/claude/)).
+- **Claude Code** — no MCP setup. Install the `zerogpu` CLI plus the marketplace plugin and you get 11 auto-invoked skills plus a cost-savings readout (see [agents/claude/](agents/claude/)).
 - **Cheap by default** — small models for trivial work, frontier model untouched for everything else.
 - **Per-call savings** — every routed task returns model, latency, and a real `savings_usd` figure.
 - **Hosted, no infra** — point your agent at `https://mcp.zerogpu.ai/mcp`. We run the routing layer.
@@ -94,7 +94,7 @@ The agent should call `zerogpu_summarize` and return a summary plus savings meta
 
 ## Claude Code quick start
 
-The Claude Code plugin ships 13 skills (one per `zerogpu` CLI command) that Claude auto-invokes when your request matches — "summarize this", "redact the PII", "classify by sentiment and topic". You can also call any skill manually with `/zerogpu-router:<name>`.
+The Claude Code plugin ships 14 skills — 11 inference skills that Claude auto-invokes when your request matches ("summarize this", "redact the PII", "classify by sentiment and topic"), plus the manual `signin`, `status`, and `cost-savings` skills. You can also call any skill manually with `/zerogpu-router:<name>`. Run `/zerogpu-router:cost-savings` anytime to see how much you've saved by routing trivial work to ZeroGPU.
 
 Grab a ZeroGPU API key and project ID at [platform.zerogpu.ai](https://platform.zerogpu.ai), then:
 

--- a/agents/claude/.claude-plugin/plugin.json
+++ b/agents/claude/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "zerogpu-router",
   "displayName": "ZeroGPU Router",
-  "version": "1.2.1",
-  "description": "Offload cheap AI tasks (classification, entity/PII/JSON extraction, small-model chat) to ZeroGPU small/nano models. Ships 12 auto-invoked skills.",
+  "version": "1.3.0",
+  "description": "Offload cheap AI tasks (classification, entity/PII/JSON extraction, small-model chat) to ZeroGPU small/nano models, and see the cost you save by doing so.",
   "author": {
     "name": "ZeroGPU",
     "email": "hello@zerogpu.ai",

--- a/agents/claude/CHANGELOG.md
+++ b/agents/claude/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 1.3.0
+
+Adds a cost-savings feature so the value of routing trivial work to ZeroGPU is visible. Every routed call records how many Claude tokens it offloaded and the estimated dollars saved, persisted in `~/.zerogpu/savings.json` (alongside the existing credentials). After some responses, a balanced random note (≈ once every 4–5 calls, never twice in a row) surfaces the running total; the new manual `cost-savings` skill prints the full breakdown on demand.
+
+Requires `zerogpu-cli` ≥ 2.3.0, which computes and stores the savings.
+
+### Added
+
+- `cost-savings` skill (`skills/cost-savings/SKILL.md`, manual-only via `disable-model-invocation: true`) — runs `zerogpu cost_savings` and relays a cumulative report: dollars saved, Claude tokens offloaded, routed-call count, per-model breakdown, and the baseline model used.
+- A `💰 ZeroGPU savings …` note that the CLI emits to stderr on a balanced random cadence after model commands. Token counts are actual (from the API `usage`); dollar figures estimate what the same tokens would have cost on Claude (default baseline `claude-opus-4-8`, overridable via `ZEROGPU_SAVINGS_MODEL`).
+
+### Changed
+
+- The 11 auto-invoked model skills (`chat`, `chat-thinking`, `classify-*`, `extract-*`, `redact-pii`, `summarize`) gained one trailing line instructing Claude to relay the `💰 ZeroGPU savings` note when present.
+- `agents/claude/.claude-plugin/plugin.json`: version `1.2.1` → `1.3.0`; `description` mentions the savings feature.
+
+### Install
+
+```
+/plugin marketplace add zerogpu/zerogpu-router
+/plugin install zerogpu-router@zerogpu
+```
+
 ## 1.2.1
 
 Renames the manual `login` skill to `signin` for clearer intent. The underlying `zerogpu login` CLI subcommand is unchanged — only the skill's name and its slash invocation move from `/zerogpu-router:login` to `/zerogpu-router:signin`. Anyone scripting the old invocation must update it.

--- a/agents/claude/README.md
+++ b/agents/claude/README.md
@@ -125,7 +125,7 @@ Call any skill explicitly with `/zerogpu-router:<name> <args>`:
 
 ## Skills in detail
 
-Each skill below documents what it does, which ZeroGPU model it runs, how to invoke it, what arguments it accepts, and what the output looks like. All inference skills auto-invoke when Claude detects a matching request; `signin` and `status` are manual-only.
+Each skill below documents what it does, which ZeroGPU model it runs, how to invoke it, what arguments it accepts, and what the output looks like. All inference skills auto-invoke when Claude detects a matching request; `signin`, `status`, and `cost-savings` are manual-only.
 
 ### `/zerogpu-router:signin`
 
@@ -171,6 +171,44 @@ Show your current ZeroGPU sign-in status and the masked API key.
 ```
 
 Exit code is `0` when signed in, `1` when not. If you're not signed in, run `/zerogpu-router:signin`.
+
+---
+
+### `/zerogpu-router:cost-savings`
+
+Show how much you've saved by routing trivial tasks to ZeroGPU instead of Claude.
+
+- **Manual only**
+- **Wraps:** `zerogpu cost_savings`
+
+**Example**
+
+```text
+/zerogpu-router:cost-savings
+```
+
+**Output (illustrative)**
+
+```text
+💰 ZeroGPU Cost Savings
+───────────────────────
+Saved so far:     ~$2.14
+Tokens offloaded: ≈ 430,120 Claude tokens
+Routed calls:     58
+Avg per call:     ~$0.04
+Since:            Apr 12, 2026
+
+By model:
+  llama-3.1-8b-instruct-fast  —  20 calls, ~$1.20, 210K tok
+  gliner2-base-v1             —  18 calls, ~$0.61, 120K tok
+  ...
+```
+
+Every routed call (chat, classify, extract, redact, summarize, …) records the Claude tokens it offloaded and the dollars saved, persisted in `~/.zerogpu/savings.json` alongside your credentials. **Token counts and ZeroGPU costs are actual** (real per-model ZeroGPU rates × the API's usage report). The **dollar savings** is the Claude spend avoided: what those exact tokens would have cost on Claude minus the real ZeroGPU cost. The Claude baseline defaults to `claude-opus-4-8` and is overridable via the `ZEROGPU_SAVINGS_MODEL` environment variable (e.g. `claude-sonnet-4-6`).
+
+You don't have to ask: after some responses a short `💰 ZeroGPU savings so far: …` note appears automatically on a balanced cadence (≈ once every 4–5 routed calls, never twice in a row) so the running total stays visible without nagging.
+
+Pass `--json` for the raw data, or `--reset` to clear the history.
 
 ---
 
@@ -551,12 +589,13 @@ a revised 2025 budget by mid-December.
 
 ## Skills reference
 
-Quick lookup table — all 13 skills at a glance.
+Quick lookup table — all 14 skills at a glance.
 
 | Skill | Purpose | Example |
 | --- | --- | --- |
 | `/zerogpu-router:signin` | Sign in and persist API key + Project ID (manual only) | `/zerogpu-router:signin` |
 | `/zerogpu-router:status` | Show current sign-in status (manual only) | `/zerogpu-router:status` |
+| `/zerogpu-router:cost-savings` | Show cumulative savings vs. Claude (manual only) | `/zerogpu-router:cost-savings` |
 | `/zerogpu-router:chat <text>` | Short chat reply via `LFM2.5-1.2B-Instruct` | `/zerogpu-router:chat "Explain WebSockets in two sentences."` |
 | `/zerogpu-router:chat-thinking <text>` | Chat with the Thinking variant (returns reasoning) | `/zerogpu-router:chat-thinking "If a train leaves at 3 PM going 60 mph, when does it cover 150 miles?"` |
 | `/zerogpu-router:classify-iab <text>` | IAB taxonomy classification | `/zerogpu-router:classify-iab "The Lakers signed a new point guard."` |

--- a/agents/claude/skills/chat-thinking/SKILL.md
+++ b/agents/claude/skills/chat-thinking/SKILL.md
@@ -16,3 +16,5 @@ zerogpu chat_thinking "$ZGPU_TEXT"
 ```
 
 The response includes the model's reasoning trace.
+
+If the command output includes a line starting with `💰 ZeroGPU savings`, relay that line to the user verbatim as a brief closing note — it shows their running ZeroGPU cost savings.

--- a/agents/claude/skills/chat/SKILL.md
+++ b/agents/claude/skills/chat/SKILL.md
@@ -21,3 +21,5 @@ ZGPU_T
 ```
 
 Never inline the prompt as a plain `"..."` string — newlines, parens, single quotes, and `$` in the user's text will break shell parsing. The heredoc form is safe for any input.
+
+If the command output includes a line starting with `💰 ZeroGPU savings`, relay that line to the user verbatim as a brief closing note — it shows their running ZeroGPU cost savings.

--- a/agents/claude/skills/classify-iab-enriched/SKILL.md
+++ b/agents/claude/skills/classify-iab-enriched/SKILL.md
@@ -16,3 +16,5 @@ zerogpu classify_iab_enriched "$ZGPU_TEXT"
 ```
 
 Output is a JSON object with `categories`, `topics`, `keywords`, and `intent`.
+
+If the command output includes a line starting with `💰 ZeroGPU savings`, relay that line to the user verbatim as a brief closing note — it shows their running ZeroGPU cost savings.

--- a/agents/claude/skills/classify-iab/SKILL.md
+++ b/agents/claude/skills/classify-iab/SKILL.md
@@ -16,3 +16,5 @@ zerogpu classify_iab "$ZGPU_TEXT"
 ```
 
 Output is a JSON list of IAB categories with confidence scores.
+
+If the command output includes a line starting with `💰 ZeroGPU savings`, relay that line to the user verbatim as a brief closing note — it shows their running ZeroGPU cost savings.

--- a/agents/claude/skills/classify-structured/SKILL.md
+++ b/agents/claude/skills/classify-structured/SKILL.md
@@ -21,3 +21,5 @@ ZGPU_T
 ```
 
 Schema is a single-quoted JSON object mapping each axis to its allowed labels. Output is a JSON object with one chosen label per category.
+
+If the command output includes a line starting with `💰 ZeroGPU savings`, relay that line to the user verbatim as a brief closing note — it shows their running ZeroGPU cost savings.

--- a/agents/claude/skills/classify-zero-shot/SKILL.md
+++ b/agents/claude/skills/classify-zero-shot/SKILL.md
@@ -21,3 +21,5 @@ ZGPU_T
 ```
 
 At least one label is required. Either repeat `-l <label>` or pass `--labels a,b,c`.
+
+If the command output includes a line starting with `💰 ZeroGPU savings`, relay that line to the user verbatim as a brief closing note — it shows their running ZeroGPU cost savings.

--- a/agents/claude/skills/cost-savings/SKILL.md
+++ b/agents/claude/skills/cost-savings/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: cost-savings
+description: Show how much you've saved by routing tasks to ZeroGPU instead of Claude — cumulative dollars and Claude tokens offloaded. Use when the user asks how much they've saved, their ZeroGPU savings, or to see the cost-savings summary.
+disable-model-invocation: true
+allowed-tools: Bash(zerogpu cost_savings*)
+---
+
+Show the ZeroGPU cost-savings summary:
+
+```!
+zerogpu cost_savings
+```
+
+Relay the report to the user as-is. Token counts are actual (from the API); dollar figures are an estimate of what the same work would have cost on Claude (default baseline `claude-opus-4-8`, overridable via the `ZEROGPU_SAVINGS_MODEL` env var). Pass `--json` for raw data or `--reset` to clear the history.

--- a/agents/claude/skills/extract-entities/SKILL.md
+++ b/agents/claude/skills/extract-entities/SKILL.md
@@ -21,3 +21,5 @@ ZGPU_T
 ```
 
 At least one `-l <label>` (or `--labels a,b,c`) is required. Optional `-t <threshold>` filters spans below a confidence (default `0.3`, must be in `[0, 1]`).
+
+If the command output includes a line starting with `💰 ZeroGPU savings`, relay that line to the user verbatim as a brief closing note — it shows their running ZeroGPU cost savings.

--- a/agents/claude/skills/extract-json/SKILL.md
+++ b/agents/claude/skills/extract-json/SKILL.md
@@ -21,3 +21,5 @@ ZGPU_T
 ```
 
 Schema is required, single-quoted JSON. Each field is `name::type::description`. Output is a JSON object keyed by group, with extracted field values.
+
+If the command output includes a line starting with `💰 ZeroGPU savings`, relay that line to the user verbatim as a brief closing note — it shows their running ZeroGPU cost savings.

--- a/agents/claude/skills/extract-pii/SKILL.md
+++ b/agents/claude/skills/extract-pii/SKILL.md
@@ -23,3 +23,5 @@ ZGPU_T
 Optional flags: `-t <threshold>` (float, default `0.5`), `-c <list>` (comma-separated categories, default `identity,contact`; other values include `financial`, `medical`, `credentials`).
 
 If the user wants the PII *masked in-line* rather than extracted, use `/zerogpu-router:redact-pii` instead.
+
+If the command output includes a line starting with `💰 ZeroGPU savings`, relay that line to the user verbatim as a brief closing note — it shows their running ZeroGPU cost savings.

--- a/agents/claude/skills/redact-pii/SKILL.md
+++ b/agents/claude/skills/redact-pii/SKILL.md
@@ -16,3 +16,5 @@ zerogpu redact_pii "$ZGPU_TEXT"
 ```
 
 Output is the original text with PII spans replaced by `[LABEL]` placeholders. For extracting (not masking) PII, use `/zerogpu-router:extract-pii`.
+
+If the command output includes a line starting with `💰 ZeroGPU savings`, relay that line to the user verbatim as a brief closing note — it shows their running ZeroGPU cost savings.

--- a/agents/claude/skills/summarize/SKILL.md
+++ b/agents/claude/skills/summarize/SKILL.md
@@ -16,3 +16,5 @@ zerogpu summarize "$ZGPU_TEXT"
 ```
 
 Output is a short condensed summary string. For files, the user can run `zerogpu summarize "$(cat article.txt)"` directly.
+
+If the command output includes a line starting with `💰 ZeroGPU savings`, relay that line to the user verbatim as a brief closing note — it shows their running ZeroGPU cost savings.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cost-savings feature tracking running totals of offloaded tokens and estimated dollar savings from routed ZeroGPU calls
  * New `/zerogpu-router:cost-savings` command displays full savings breakdown with per-model details and baseline model configuration

* **Documentation**
  * Updated plugin documentation, README, and skill descriptions to reflect cost-savings functionality and new command availability

* **Chores**
  * Plugin version updated to 1.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->