### PR TITLE
feat: add OpenClaw plugin icon

### DIFF
--- a/agents/openclaw/plugin/openclaw.plugin.json
+++ b/agents/openclaw/plugin/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "zerogpu-router",
   "name": "ZeroGPU Router",
   "description": "Route trivial AI tasks (classification, summarization, extraction, PII redaction, small-model chat) to ZeroGPU small/nano models via ZeroGPU CLI.",
+  "icon": "https://avatars.githubusercontent.com/u/242287374?v=4",
   "version": "2.0.0",
   "skills": [
     "./skills/chat",


### PR DESCRIPTION
## Summary

Add ZeroGPU's official organization mark to the OpenClaw plugin manifest so ClawHub and other catalog surfaces can render branded artwork instead of the generic fallback.

## Validation

- Parsed `agents/openclaw/plugin/openclaw.plugin.json` with `jq`
- Verified the HTTPS icon URL returns `image/png`

## Release

Released by @amaan-ai20 in `zerogpu-openclaw-plugin--v2.1.0`. The release added the changelog entry and bumped both plugin manifests, so no additional version-bump PR is needed.
