### PR TITLE
openclaw: fix gateway crash-loop on 2026.7.1 upgrade (v3.0.1)

### DIFF
--- a/agents/openclaw/CHANGELOG.md
+++ b/agents/openclaw/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 3.0.1
+
+Fixes a gateway boot failure on OpenClaw `2026.7.1`. Installs of this plugin could leave the gateway
+crash-looping after an OpenClaw upgrade, never reporting ready. **No skill behavior or output changes.**
+
+### Fixed
+- Removed `peerDependencies.openclaw` from the published `plugin/package.json`. `2026.7.1` added a
+  startup plugin-convergence gate that fails closed: for any plugin whose shipped manifest declares
+  an `openclaw` peer, it audits that the plugin's `node_modules/openclaw` symlink still resolves to
+  the *live* host package root. That symlink is an absolute path written once at plugin-install time,
+  so an OpenClaw upgrade that relocates the package root (notably a Node version change — `2026.7.1`
+  narrowed `engines.node` to `>=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0`, and per-version global
+  prefixes under nvm/fnm/volta move with it) leaves it stale. The audit then fails with
+  `missing-openclaw-peer-link` and the gateway refuses to report ready.
+
+  The gateway's own repair pass for this (`repairManagedNpmOpenClawPeerLinks`) only walks managed npm
+  roots under `~/.openclaw/npm`. This plugin installs as a ClawHub code-plugin into
+  `~/.openclaw/extensions`, so it was audited but never repaired — the failure persisted across every
+  restart instead of self-healing.
+
+  The peer declaration was never needed at runtime: the host loader aliases `openclaw/plugin-sdk/*`
+  to its own modules, so `dist/index.js` resolves `definePluginEntry` without the symlink. `openclaw`
+  stays in `devDependencies` for the build and type-check, which are unchanged.
+
+**Recovering an already-broken install:** the gate reads the `package.json` of the *installed* copy
+under `~/.openclaw/extensions/`, so that directory has to be replaced — publishing this release does
+not repair machines on its own. Reinstalling in place clears the failure:
+
+```sh
+openclaw plugins install clawhub:zerogpu-router --force
+```
+
+`--force` is required: a plain `plugins install` refuses when the plugin directory already exists.
+To only unbrick the gateway without reinstalling, `openclaw plugins uninstall zerogpu-router --force`
+also restores boot. Note that `openclaw plugins update` skips `path`-source installs entirely.
+
 ## 3.0.0
 
 Security and compliance release. Resolves every finding from the ClawHub security audit and moves the plugin onto a patched OpenClaw gateway. **Breaking:** the minimum supported gateway is now `2026.7.1` — older gateways can no longer install this version.

--- a/agents/openclaw/plugin/package-lock.json
+++ b/agents/openclaw/plugin/package-lock.json
@@ -14,9 +14,6 @@
       },
       "engines": {
         "node": ">=22"
-      },
-      "peerDependencies": {
-        "openclaw": ">=2026.7.1"
       }
     },
     "node_modules/openclaw": {

--- a/agents/openclaw/plugin/package.json
+++ b/agents/openclaw/plugin/package.json
@@ -59,9 +59,6 @@
       "pluginSdkVersion": "2026.7.1"
     }
   },
-  "peerDependencies": {
-    "openclaw": ">=2026.7.1"
-  },
   "devDependencies": {
     "openclaw": "^2026.7.1",
     "typescript": "^5.0.0"


### PR DESCRIPTION
OpenClaw 2026.7.1 added a startup plugin-convergence gate that runs before
gateway readiness and fails closed. For any plugin whose shipped manifest
declares an `openclaw` peer dependency, it audits that the plugin's
node_modules/openclaw symlink still resolves to the live host package root.

That symlink is an absolute path written once at plugin-install time. An
OpenClaw upgrade that relocates the package root leaves it stale — notably a
Node version change, since 2026.7.1 narrowed engines.node to
">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0" and per-version global prefixes
under nvm/fnm/volta move with it. The audit then fails with
missing-openclaw-peer-link and the gateway never reports ready, so the
supervisor restarts it in a loop.

The gateway's own repair for this (repairManagedNpmOpenClawPeerLinks) only
walks managed npm roots under ~/.openclaw/npm. This plugin installs as a
ClawHub code-plugin into ~/.openclaw/extensions, so it was audited but never
repaired and could not self-heal across restarts.

The peer declaration was never needed at runtime: the host loader aliases
openclaw/plugin-sdk/* to its own modules, so dist/index.js resolves
definePluginEntry without the symlink. openclaw stays in devDependencies for
the build and type-check, which are unchanged. No skill behavior changes.

Verified against a real openclaw 2026.7.1 install, driving the gateway's own
runPluginPayloadSmokeCheck:

  scenario                          3.0.0      3.0.1
  link correct (fresh install)      ok         ok
  link stale (post-upgrade)         BLOCKED    ok
  link absent entirely              BLOCKED    ok

With the fix and node_modules removed entirely, `plugins doctor` reports no
issues, `plugins inspect` reports Status: loaded, and all 13 model-invocable
skills still register.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VkBGghk3XAfJMyDCrMFaVL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a gateway startup issue that could cause upgraded installations to enter a crash loop instead of becoming ready.
  * Improved startup readiness handling for installations where package locations change during upgrades.
  * Added recovery guidance for installations already affected by the issue.

* **Chores**
  * Updated the OpenClaw plugin to version 3.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->