### PR TITLE
Add skills for the models the docs catalog gained

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "zerogpu-router",
       "source": "./agents/claude",
-      "description": "Route classification, summarization, entity/PII/JSON extraction, follow-ups, and short chat to ZeroGPU small/nano models — 14 auto-invoked skills.",
+      "description": "Route classification, domain classification, summarization, entity/PII/JSON extraction, follow-ups, and small- to mid-model chat to ZeroGPU — 18 auto-invoked skills.",
       "category": "productivity",
       "tags": ["nlp", "classification", "summarization", "extraction", "pii", "ner", "cost-optimization", "small-models"]
     }

--- a/agents/claude/CHANGELOG.md
+++ b/agents/claude/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 1.6.0
+
+Catches the plugin up to the [ZeroGPU model catalog](https://docs.zerogpu.ai/docs/model-catalog), which added three models and renamed a fourth. **Four new skills; the existing 14 are unchanged.**
+
+### Added
+
+- `generate-followups` — suggested next questions for a passage, "people also ask" style. Model `zlm-v1-followup-questions-edge`, wrapping `zerogpu generate_followups`. The CLI has shipped this command since 3.1.0; the plugin never exposed it.
+- `classify-domain` — IAB classification from a bare hostname, no page fetch. Model `zlm-v1-iab-domain-classifier`. Full URLs are normalized down to the hostname, so `https://www.nytimes.com/section/world?x=1` and `nytimes.com` behave identically. Payloads run up to 10x smaller than sending page text, which is the point for bidstream enrichment and allow/deny-list scoring.
+- `chat-gpt-oss` — heavier chat via `gpt-oss-120b` (117B MoE, 131,072-token context) for long documents and multi-step instructions the 1.2B edge models can't carry.
+- `chat-qwen` — heavier multilingual chat via `qwen3-30b-a3b-fp8` (30.5B MoE, 100+ languages). This model is served on Chat Completions only, so the skill posts to `/v1/chat/completions` rather than `/v1/responses`.
+
+Both chat models return an internal reasoning trace. The skills deliberately drop it and print only the final answer, matching how `chat` behaves — `chat-thinking` remains the skill that surfaces reasoning.
+
+### Changed
+
+- `classify-iab-enriched` — documented model renamed `zlm-v1-iab-classify-edge-enriched` → `zlm-v2-iab-classify-edge-enriched`, following the catalog. No behavior change: the skill still shells out to `zerogpu classify_iab_enriched`, and the API resolves both ids to the same model.
+- `.claude-plugin/marketplace.json` — description now reflects 18 skills and mentions domain classification.
+
+### Known limitation
+
+`classify-domain`, `chat-gpt-oss`, and `chat-qwen` call `https://api.zerogpu.ai` directly, because `zerogpu-cli` (3.2.0, current) has no command for these three models. They read the same credentials — `~/.zerogpu/config.json`, falling back to `$ZEROGPU_API_KEY` — and fail with the same "run `zerogpu login`" message when unauthenticated, but since the CLI isn't in the call path it can't record the call: **these three do not contribute to `/zerogpu-router:cost-savings`**. The other 15 skills are unaffected. When the CLI adds commands for these models, the skills move onto it and start counting.
+
+### Install
+
+```
+/plugin marketplace add zerogpu/zerogpu-router
+/plugin install zerogpu-router@zerogpu
+```
+
 ## 1.5.1
 
 Cost-savings copy is now host-neutral, and the dollar figure is a rounded estimate. The `💰 ZeroGPU savings` note and the `cost-savings` report previously said "Claude" for the pricing baseline — the same word as the agent host, so "Claude savings" was ambiguous. They now compare against **"your frontier model"** and count **"frontier-model tokens offloaded."** **The 11 auto-invoked model skills and their outputs are unchanged** — they still relay whatever the CLI emits, verbatim.

--- a/agents/claude/CHANGELOG.md
+++ b/agents/claude/CHANGELOG.md
@@ -2,25 +2,26 @@
 
 ## 1.6.0
 
-Catches the plugin up to the [ZeroGPU model catalog](https://docs.zerogpu.ai/docs/model-catalog), which added three models and renamed a fourth. **Four new skills; the existing 14 are unchanged.**
+Catches the plugin up to the [ZeroGPU model catalog](https://docs.zerogpu.ai/docs/model-catalog), which added three models and renamed a fourth, and to `zerogpu-cli` 3.3.0, which added the commands to reach them. **Four new skills; the existing 14 are unchanged.**
+
+Requires `zerogpu-cli` **≥ 3.3.0** for the three new model skills — `chat --model` and `classify_domain` landed in that release. The other 15 skills still work on any 3.x.
 
 ### Added
 
 - `generate-followups` — suggested next questions for a passage, "people also ask" style. Model `zlm-v1-followup-questions-edge`, wrapping `zerogpu generate_followups`. The CLI has shipped this command since 3.1.0; the plugin never exposed it.
-- `classify-domain` — IAB classification from a bare hostname, no page fetch. Model `zlm-v1-iab-domain-classifier`. Full URLs are normalized down to the hostname, so `https://www.nytimes.com/section/world?x=1` and `nytimes.com` behave identically. Payloads run up to 10x smaller than sending page text, which is the point for bidstream enrichment and allow/deny-list scoring.
-- `chat-gpt-oss` — heavier chat via `gpt-oss-120b` (117B MoE, 131,072-token context) for long documents and multi-step instructions the 1.2B edge models can't carry.
-- `chat-qwen` — heavier multilingual chat via `qwen3-30b-a3b-fp8` (30.5B MoE, 100+ languages). This model is served on Chat Completions only, so the skill posts to `/v1/chat/completions` rather than `/v1/responses`.
+- `classify-domain` — IAB classification from a bare hostname, no page fetch. Model `zlm-v1-iab-domain-classifier`, wrapping `zerogpu classify_domain`. Payloads run up to 10x smaller than sending page text, which is the point for bidstream enrichment and allow/deny-list scoring. Claude strips the scheme, path, and query before calling, so pasting a full URL works.
+- `chat-gpt-oss` — heavier chat via `gpt-oss-120b` (117B MoE, 131,072-token context) for long documents and multi-step instructions the 1.2B edge models can't carry. Wraps `zerogpu chat -m gpt-oss-120b`.
+- `chat-qwen` — heavier multilingual chat via `qwen3-30b-a3b-fp8` (30.5B MoE, 100+ languages). Wraps `zerogpu chat -m qwen3-30b-a3b-fp8`; this model is served by the Chat Completions API rather than the Responses API, which the CLI handles.
 
-Both chat models return an internal reasoning trace. The skills deliberately drop it and print only the final answer, matching how `chat` behaves — `chat-thinking` remains the skill that surfaces reasoning.
+Both new chat models return a reasoning trace. Neither skill passes the CLI's `-r` flag, so only the final answer is printed — matching how `chat` behaves. `chat-thinking` remains the skill that surfaces reasoning.
+
+Savings tracking covers all four: every call goes through the CLI, and 3.3.0 prices each of these models in its savings table, so they contribute to `/zerogpu-router:cost-savings` like any other skill.
 
 ### Changed
 
-- `classify-iab-enriched` — documented model renamed `zlm-v1-iab-classify-edge-enriched` → `zlm-v2-iab-classify-edge-enriched`, following the catalog. No behavior change: the skill still shells out to `zerogpu classify_iab_enriched`, and the API resolves both ids to the same model.
+- `classify-iab-enriched` — documented model renamed `zlm-v1-iab-classify-edge-enriched` → `zlm-v2-iab-classify-edge-enriched`, following the catalog and CLI 3.3.0. No behavior change: the skill still shells out to `zerogpu classify_iab_enriched`.
 - `.claude-plugin/marketplace.json` — description now reflects 18 skills and mentions domain classification.
-
-### Known limitation
-
-`classify-domain`, `chat-gpt-oss`, and `chat-qwen` call `https://api.zerogpu.ai` directly, because `zerogpu-cli` (3.2.0, current) has no command for these three models. They read the same credentials — `~/.zerogpu/config.json`, falling back to `$ZEROGPU_API_KEY` — and fail with the same "run `zerogpu login`" message when unauthenticated, but since the CLI isn't in the call path it can't record the call: **these three do not contribute to `/zerogpu-router:cost-savings`**. The other 15 skills are unaffected. When the CLI adds commands for these models, the skills move onto it and start counting.
+- `README.md` — prerequisites now call out the `zerogpu-cli` ≥ 3.3.0 floor.
 
 ### Install
 

--- a/agents/claude/README.md
+++ b/agents/claude/README.md
@@ -2,7 +2,7 @@
 
 Offload cheap, well-defined NLP tasks (classification, summarization, entity & PII extraction, short chat) from Claude to ZeroGPU's edge-optimized small language models — directly from your Claude Code session.
 
-Every command in the `zerogpu` CLI is exposed as a Claude Code skill, plus three skills for models the CLI does not yet cover. Claude auto-invokes the right skill when your request matches (e.g. "redact the PII in this paragraph", "summarize this article", "classify this by sentiment and topic"), or you can call any of them by name with `/zerogpu-router:<skill>`.
+Every command in the `zerogpu` CLI is exposed as a Claude Code skill. Claude auto-invokes the right skill when your request matches (e.g. "redact the PII in this paragraph", "summarize this article", "classify this by sentiment and topic"), or you can call any of them by name with `/zerogpu-router:<skill>`.
 
 ---
 
@@ -14,14 +14,16 @@ Every command in the `zerogpu` CLI is exposed as a Claude Code skill, plus three
 | --- | --- | --- |
 | **Node.js ≥ 20** | Runs the `zerogpu` CLI | [nodejs.org](https://nodejs.org) |
 | **Claude Code** | Hosts the plugin | `npm install -g @anthropic-ai/claude-code` |
-| **`zerogpu` CLI** | Skills shell out to it | `npm install -g zerogpu-cli` |
+| **`zerogpu` CLI ≥ 3.3.0** | Skills shell out to it | `npm install -g zerogpu-cli@latest` |
 | **ZeroGPU account** | API key | [zerogpu.ai](https://zerogpu.ai) |
 
-Verify the CLI is on your `PATH`:
+Verify the CLI is on your `PATH` and current:
 
 ```sh
 zerogpu --version
 ```
+
+`chat-gpt-oss`, `chat-qwen`, and `classify-domain` need **3.3.0 or newer** — that release added `chat --model` and the `classify_domain` command. On an older CLI those three skills fail; the other 15 work on any 3.x.
 
 ### 1. Authenticate the CLI
 
@@ -262,13 +264,13 @@ Same as `chat`, but the model returns its reasoning trace alongside the answer.
 Heavier chat for work the 1.2B edge models can't carry — long documents, multi-step instructions, harder general-knowledge questions — at a fraction of frontier-model cost.
 
 - **Model:** `gpt-oss-120b` (117B MoE, 131,072-token context)
-- **Calls:** `POST /v1/responses` directly — the `zerogpu` CLI has no command for this model
+- **Wraps:** `zerogpu chat -m gpt-oss-120b`
 - **When Claude auto-invokes:** you've signalled "use a bigger ZeroGPU model", or a routed task came back too weak from `chat`.
 
 **Synopsis**
 
 ```
-/zerogpu-router:chat-gpt-oss <text>
+/zerogpu-router:chat-gpt-oss <text> [-i <instructions>]
 ```
 
 **Example**
@@ -277,9 +279,7 @@ Heavier chat for work the 1.2B edge models can't carry — long documents, multi
 /zerogpu-router:chat-gpt-oss "Summarize the trade-offs between optimistic and pessimistic locking, then recommend one for a high-contention inventory table."
 ```
 
-**Output:** the assistant's answer as plain text. The model emits an internal reasoning trace as well; the skill drops it and prints only the final answer.
-
-Usage is **not** recorded in `/zerogpu-router:cost-savings` (see [Skills that bypass the CLI](#skills-that-bypass-the-cli)).
+**Output:** the assistant's answer as plain text. The model emits a reasoning trace as well; the skill leaves off the CLI's `-r` flag, so only the final answer is printed.
 
 ---
 
@@ -288,13 +288,13 @@ Usage is **not** recorded in `/zerogpu-router:cost-savings` (see [Skills that by
 Heavier chat tuned for multilingual work — 100+ languages, useful when the prompt or the expected answer isn't English.
 
 - **Model:** `qwen3-30b-a3b-fp8` (30.5B MoE, 32,768-token context)
-- **Calls:** `POST /v1/chat/completions` directly — this model isn't served on the Responses endpoint, and the CLI has no command for it
+- **Wraps:** `zerogpu chat -m qwen3-30b-a3b-fp8`
 - **When Claude auto-invokes:** non-English prompts, translation-adjacent tasks, mid-weight questions the edge models handle poorly.
 
 **Synopsis**
 
 ```
-/zerogpu-router:chat-qwen <text>
+/zerogpu-router:chat-qwen <text> [-i <instructions>]
 ```
 
 **Example**
@@ -303,9 +303,7 @@ Heavier chat tuned for multilingual work — 100+ languages, useful when the pro
 /zerogpu-router:chat-qwen "Explica la diferencia entre un índice B-tree y uno hash en dos frases."
 ```
 
-**Output:** the assistant's answer as plain text. The model returns its reasoning in a separate field; the skill drops it.
-
-Usage is **not** recorded in `/zerogpu-router:cost-savings` (see [Skills that bypass the CLI](#skills-that-bypass-the-cli)).
+**Output:** the assistant's answer as plain text. This model is served by the Chat Completions API rather than the Responses API — the CLI routes it automatically. Its reasoning trace is omitted, since the skill doesn't pass `-r`.
 
 ---
 
@@ -379,16 +377,16 @@ Enriched IAB classification — audience categories **plus** topics, keywords, a
 Classify a **domain name** against the IAB taxonomy without fetching the page. Built for bidstream enrichment and allow/deny-list scoring, where all you have is a hostname.
 
 - **Model:** `zlm-v1-iab-domain-classifier`
-- **Calls:** `POST /v1/responses` directly — the `zerogpu` CLI has no command for this model
+- **Wraps:** `zerogpu classify_domain`
 - **When Claude auto-invokes:** "what is example.com about?", "categorize these domains", any IAB request where the input is a URL rather than article text.
 
 **Synopsis**
 
 ```
-/zerogpu-router:classify-domain <domain-or-url>
+/zerogpu-router:classify-domain <domain>
 ```
 
-Full URLs are normalized down to the hostname, so `https://www.nytimes.com/section/world?x=1` and `nytimes.com` behave identically.
+The model takes a bare hostname — Claude strips the scheme, path, and query before calling, so pasting `https://www.nytimes.com/section/world?x=1` works too.
 
 **Example**
 
@@ -411,8 +409,6 @@ Full URLs are normalized down to the hostname, so `https://www.nytimes.com/secti
 ```
 
 Payloads are up to 10x smaller than sending page text. If you have the actual article, use `classify-iab` or `classify-iab-enriched` instead — they see more signal.
-
-Usage is **not** recorded in `/zerogpu-router:cost-savings` (see [Skills that bypass the CLI](#skills-that-bypass-the-cli)).
 
 ---
 
@@ -702,16 +698,6 @@ Generate the questions a reader would naturally ask next about a passage — "pe
   "How do other central banks handle similar inflation?"
 ]
 ```
-
----
-
-## Skills that bypass the CLI
-
-Three skills — `classify-domain`, `chat-gpt-oss`, and `chat-qwen` — cover models the `zerogpu` CLI has no command for, so they POST to `https://api.zerogpu.ai` themselves.
-
-They use the same credentials as every other skill: the API key `zerogpu login` wrote to `~/.zerogpu/config.json`, falling back to `$ZEROGPU_API_KEY`. If you're not signed in they fail with the same instruction to run `zerogpu login`. They need `node` on your `PATH`, which the CLI already requires.
-
-The one behavioral difference: because the CLI isn't in the call path, it can't record the call, so **these three do not contribute to `/zerogpu-router:cost-savings`**. Your savings total will under-report by whatever you route through them. The other 15 skills are unaffected. Once `zerogpu-cli` ships commands for these models, the skills will move onto it and start counting.
 
 ---
 

--- a/agents/claude/README.md
+++ b/agents/claude/README.md
@@ -2,7 +2,7 @@
 
 Offload cheap, well-defined NLP tasks (classification, summarization, entity & PII extraction, short chat) from Claude to ZeroGPU's edge-optimized small language models — directly from your Claude Code session.
 
-Every command in the `zerogpu` CLI is exposed as a Claude Code skill. Claude auto-invokes the right skill when your request matches (e.g. "redact the PII in this paragraph", "summarize this article", "classify this by sentiment and topic"), or you can call any of them by name with `/zerogpu-router:<skill>`.
+Every command in the `zerogpu` CLI is exposed as a Claude Code skill, plus three skills for models the CLI does not yet cover. Claude auto-invokes the right skill when your request matches (e.g. "redact the PII in this paragraph", "summarize this article", "classify this by sentiment and topic"), or you can call any of them by name with `/zerogpu-router:<skill>`.
 
 ---
 
@@ -257,6 +257,58 @@ Same as `chat`, but the model returns its reasoning trace alongside the answer.
 
 ---
 
+### `/zerogpu-router:chat-gpt-oss`
+
+Heavier chat for work the 1.2B edge models can't carry — long documents, multi-step instructions, harder general-knowledge questions — at a fraction of frontier-model cost.
+
+- **Model:** `gpt-oss-120b` (117B MoE, 131,072-token context)
+- **Calls:** `POST /v1/responses` directly — the `zerogpu` CLI has no command for this model
+- **When Claude auto-invokes:** you've signalled "use a bigger ZeroGPU model", or a routed task came back too weak from `chat`.
+
+**Synopsis**
+
+```
+/zerogpu-router:chat-gpt-oss <text>
+```
+
+**Example**
+
+```text
+/zerogpu-router:chat-gpt-oss "Summarize the trade-offs between optimistic and pessimistic locking, then recommend one for a high-contention inventory table."
+```
+
+**Output:** the assistant's answer as plain text. The model emits an internal reasoning trace as well; the skill drops it and prints only the final answer.
+
+Usage is **not** recorded in `/zerogpu-router:cost-savings` (see [Skills that bypass the CLI](#skills-that-bypass-the-cli)).
+
+---
+
+### `/zerogpu-router:chat-qwen`
+
+Heavier chat tuned for multilingual work — 100+ languages, useful when the prompt or the expected answer isn't English.
+
+- **Model:** `qwen3-30b-a3b-fp8` (30.5B MoE, 32,768-token context)
+- **Calls:** `POST /v1/chat/completions` directly — this model isn't served on the Responses endpoint, and the CLI has no command for it
+- **When Claude auto-invokes:** non-English prompts, translation-adjacent tasks, mid-weight questions the edge models handle poorly.
+
+**Synopsis**
+
+```
+/zerogpu-router:chat-qwen <text>
+```
+
+**Example**
+
+```text
+/zerogpu-router:chat-qwen "Explica la diferencia entre un índice B-tree y uno hash en dos frases."
+```
+
+**Output:** the assistant's answer as plain text. The model returns its reasoning in a separate field; the skill drops it.
+
+Usage is **not** recorded in `/zerogpu-router:cost-savings` (see [Skills that bypass the CLI](#skills-that-bypass-the-cli)).
+
+---
+
 ### `/zerogpu-router:classify-iab`
 
 Classify text against the **IAB content / audience taxonomy** (standard ad-tech category labels).
@@ -293,7 +345,7 @@ Classify text against the **IAB content / audience taxonomy** (standard ad-tech 
 
 Enriched IAB classification — audience categories **plus** topics, keywords, and inferred user intent.
 
-- **Model:** `zlm-v1-iab-classify-edge-enriched`
+- **Model:** `zlm-v2-iab-classify-edge-enriched`
 - **Wraps:** `zerogpu classify_iab_enriched`
 - **When Claude auto-invokes:** "give me topics, keywords, and intent", richer ad/audience signals than plain IAB labels.
 
@@ -319,6 +371,48 @@ Enriched IAB classification — audience categories **plus** topics, keywords, a
   "intent": "comparison-shopping"
 }
 ```
+
+---
+
+### `/zerogpu-router:classify-domain`
+
+Classify a **domain name** against the IAB taxonomy without fetching the page. Built for bidstream enrichment and allow/deny-list scoring, where all you have is a hostname.
+
+- **Model:** `zlm-v1-iab-domain-classifier`
+- **Calls:** `POST /v1/responses` directly — the `zerogpu` CLI has no command for this model
+- **When Claude auto-invokes:** "what is example.com about?", "categorize these domains", any IAB request where the input is a URL rather than article text.
+
+**Synopsis**
+
+```
+/zerogpu-router:classify-domain <domain-or-url>
+```
+
+Full URLs are normalized down to the hostname, so `https://www.nytimes.com/section/world?x=1` and `nytimes.com` behave identically.
+
+**Example**
+
+```text
+/zerogpu-router:classify-domain "espn.com"
+```
+
+**Output (illustrative, truncated)**
+
+```json
+{
+  "audience": [
+    { "id": 512, "name": "Sports Radio", "tier1_name": "Interest", "score": 0.66 }
+  ],
+  "content": {
+    "iab_1_0": [{ "code": "IAB17", "name": "Sports", "tier": 1, "score": 0.79 }],
+    "iab_2_2": [{ "id": 483, "name": "Sports", "tier1_name": "Sports", "score": 0.79 }]
+  }
+}
+```
+
+Payloads are up to 10x smaller than sending page text. If you have the actual article, use `classify-iab` or `classify-iab-enriched` instead — they see more signal.
+
+Usage is **not** recorded in `/zerogpu-router:cost-savings` (see [Skills that bypass the CLI](#skills-that-bypass-the-cli)).
 
 ---
 
@@ -579,9 +673,51 @@ a revised 2025 budget by mid-December.
 
 ---
 
+### `/zerogpu-router:generate-followups`
+
+Generate the questions a reader would naturally ask next about a passage — "people also ask" style prompts, conversation continuations, suggested next steps.
+
+- **Model:** `zlm-v1-followup-questions-edge`
+- **Wraps:** `zerogpu generate_followups`
+- **When Claude auto-invokes:** "what should I ask next?", "suggest follow-up questions", building a related-questions widget.
+
+**Synopsis**
+
+```
+/zerogpu-router:generate-followups <text>
+```
+
+**Example**
+
+```text
+/zerogpu-router:generate-followups "The Fed held rates steady at its March meeting, citing sticky core inflation."
+```
+
+**Output (illustrative)**
+
+```json
+[
+  "What are the implications of this decision?",
+  "Can you provide more context on the Fed's recent moves?",
+  "How do other central banks handle similar inflation?"
+]
+```
+
+---
+
+## Skills that bypass the CLI
+
+Three skills — `classify-domain`, `chat-gpt-oss`, and `chat-qwen` — cover models the `zerogpu` CLI has no command for, so they POST to `https://api.zerogpu.ai` themselves.
+
+They use the same credentials as every other skill: the API key `zerogpu login` wrote to `~/.zerogpu/config.json`, falling back to `$ZEROGPU_API_KEY`. If you're not signed in they fail with the same instruction to run `zerogpu login`. They need `node` on your `PATH`, which the CLI already requires.
+
+The one behavioral difference: because the CLI isn't in the call path, it can't record the call, so **these three do not contribute to `/zerogpu-router:cost-savings`**. Your savings total will under-report by whatever you route through them. The other 15 skills are unaffected. Once `zerogpu-cli` ships commands for these models, the skills will move onto it and start counting.
+
+---
+
 ## Skills reference
 
-Quick lookup table — all 14 skills at a glance.
+Quick lookup table — all 18 skills at a glance.
 
 | Skill | Purpose | Example |
 | --- | --- | --- |
@@ -590,8 +726,11 @@ Quick lookup table — all 14 skills at a glance.
 | `/zerogpu-router:cost-savings` | Show cumulative savings vs. Claude (manual only) | `/zerogpu-router:cost-savings` |
 | `/zerogpu-router:chat <text>` | Short chat reply via `LFM2.5-1.2B-Instruct` | `/zerogpu-router:chat "Explain WebSockets in two sentences."` |
 | `/zerogpu-router:chat-thinking <text>` | Chat with the Thinking variant (returns reasoning) | `/zerogpu-router:chat-thinking "If a train leaves at 3 PM going 60 mph, when does it cover 150 miles?"` |
+| `/zerogpu-router:chat-gpt-oss <text>` | Heavier chat via `gpt-oss-120b` (131K context) | `/zerogpu-router:chat-gpt-oss "Compare optimistic vs pessimistic locking."` |
+| `/zerogpu-router:chat-qwen <text>` | Heavier multilingual chat via `qwen3-30b-a3b-fp8` | `/zerogpu-router:chat-qwen "Explica los índices B-tree en dos frases."` |
 | `/zerogpu-router:classify-iab <text>` | IAB taxonomy classification | `/zerogpu-router:classify-iab "The Lakers signed a new point guard."` |
 | `/zerogpu-router:classify-iab-enriched <text>` | IAB + topics/keywords/intent | `/zerogpu-router:classify-iab-enriched "Compare the Tesla Model Y and Hyundai Ioniq 5."` |
+| `/zerogpu-router:classify-domain <domain>` | IAB classification from a hostname, no page fetch | `/zerogpu-router:classify-domain "espn.com"` |
 | `/zerogpu-router:classify-zero-shot <text> -l …` | Zero-shot against custom labels | `/zerogpu-router:classify-zero-shot "fast laptop" -l positive -l negative` |
 | `/zerogpu-router:classify-structured <text> -s '…'` | Schema-based multi-axis classification | `/zerogpu-router:classify-structured "ticket text" -s '{"sentiment":["positive","negative"]}'` |
 | `/zerogpu-router:extract-entities <text> -l …` | Custom-label NER | `/zerogpu-router:extract-entities "Tim Cook met Sundar Pichai in Cupertino." -l person -l location` |
@@ -599,6 +738,7 @@ Quick lookup table — all 14 skills at a glance.
 | `/zerogpu-router:redact-pii <text>` | Mask PII in-line with `[LABEL]` placeholders | `/zerogpu-router:redact-pii "Email John at john@acme.com"` |
 | `/zerogpu-router:extract-json <text> -s '…'` | Schema-driven JSON extraction | `/zerogpu-router:extract-json "..." -s '{"contact":["name::str::Full name"]}'` |
 | `/zerogpu-router:summarize <text>` | Summarize with `llama-3.1-8b-instruct-fast` | `/zerogpu-router:summarize "The board met Thursday to review Q3 results..."` |
+| `/zerogpu-router:generate-followups <text>` | Suggested next questions for a passage | `/zerogpu-router:generate-followups "The Fed held rates steady..."` |
 
 For full flag reference (thresholds, categories, schema syntax), run `zerogpu <command> --help`.
 

--- a/agents/claude/skills/chat-gpt-oss/SKILL.md
+++ b/agents/claude/skills/chat-gpt-oss/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: chat-gpt-oss
+description: Chat with gpt-oss-120b, ZeroGPU's largest open-weight model (117B MoE, 131K context). Use when a task needs more capability than the 1.2B edge models can give — longer documents, multi-step instructions, harder general-knowledge questions — but still does not warrant Claude.
+argument-hint: "<text>"
+allowed-tools: Bash(node -e *)
+---
+
+Call gpt-oss-120b. `$ARGUMENTS` is the raw prompt — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+export ZGPU_TEXT
+node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}fetch("https://api.zerogpu.ai/v1/responses",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"gpt-oss-120b",input:process.env.ZGPU_TEXT})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const m=(d.output||[]).find(o=>o.type==="message");const t=m&&(m.content||[]).find(c=>c.type==="output_text");console.log(t?t.text:JSON.stringify(d,null,2))}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+```
+
+Output is the assistant's answer as plain text. The model also produces an internal reasoning trace; the command above deliberately drops it and prints only the final answer. Relay that answer as-is — do not rewrite or expand it.
+
+This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in `/zerogpu-router:cost-savings`.

--- a/agents/claude/skills/chat-gpt-oss/SKILL.md
+++ b/agents/claude/skills/chat-gpt-oss/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: chat-gpt-oss
 description: Chat with gpt-oss-120b, ZeroGPU's largest open-weight model (117B MoE, 131K context). Use when a task needs more capability than the 1.2B edge models can give — longer documents, multi-step instructions, harder general-knowledge questions — but still does not warrant Claude.
-argument-hint: "<text>"
-allowed-tools: Bash(node -e *)
+argument-hint: "<text> [-i <instructions>]"
+allowed-tools: Bash(zerogpu chat *)
 ---
 
 Call gpt-oss-120b. `$ARGUMENTS` is the raw prompt — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
@@ -12,10 +12,11 @@ ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
 $ARGUMENTS
 ZGPU_END_OF_INPUT
 )
-export ZGPU_TEXT
-node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}fetch("https://api.zerogpu.ai/v1/responses",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"gpt-oss-120b",input:process.env.ZGPU_TEXT})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const m=(d.output||[]).find(o=>o.type==="message");const t=m&&(m.content||[]).find(c=>c.type==="output_text");console.log(t?t.text:JSON.stringify(d,null,2))}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+zerogpu chat "$ZGPU_TEXT" -m gpt-oss-120b
 ```
 
-Output is the assistant's answer as plain text. The model also produces an internal reasoning trace; the command above deliberately drops it and prints only the final answer. Relay that answer as-is — do not rewrite or expand it.
+If the user supplied system instructions, append `-i "<instructions>"` after the model flag.
 
-This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in `/zerogpu-router:cost-savings`.
+Output is the assistant's answer as plain text. The model also produces a reasoning trace; this skill omits the CLI's `-r` flag so only the final answer is printed. Relay that answer as-is — do not rewrite or expand it.
+
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest `/zerogpu-router:cost-savings` — this note is intentionally occasional, not shown every time.

--- a/agents/claude/skills/chat-qwen/SKILL.md
+++ b/agents/claude/skills/chat-qwen/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: chat-qwen
+description: Chat with qwen3-30b-a3b-fp8, a 30.5B MoE model with strong multilingual coverage (100+ languages, 32K context). Use for non-English prompts, translation-adjacent tasks, or mid-weight questions the 1.2B edge models handle poorly.
+argument-hint: "<text>"
+allowed-tools: Bash(node -e *)
+---
+
+Call qwen3-30b-a3b-fp8. `$ARGUMENTS` is the raw prompt — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+export ZGPU_TEXT
+node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}fetch("https://api.zerogpu.ai/v1/chat/completions",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"qwen3-30b-a3b-fp8",messages:[{role:"user",content:process.env.ZGPU_TEXT}]})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const c=d.choices&&d.choices[0]&&d.choices[0].message&&d.choices[0].message.content;console.log(c?c.trim():JSON.stringify(d,null,2))}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+```
+
+This model is served on Chat Completions only — the Responses endpoint is not available for it. Output is the assistant's answer as plain text; the model's separate reasoning field is deliberately dropped. Relay the answer as-is — do not rewrite or expand it.
+
+This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in `/zerogpu-router:cost-savings`.

--- a/agents/claude/skills/chat-qwen/SKILL.md
+++ b/agents/claude/skills/chat-qwen/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: chat-qwen
 description: Chat with qwen3-30b-a3b-fp8, a 30.5B MoE model with strong multilingual coverage (100+ languages, 32K context). Use for non-English prompts, translation-adjacent tasks, or mid-weight questions the 1.2B edge models handle poorly.
-argument-hint: "<text>"
-allowed-tools: Bash(node -e *)
+argument-hint: "<text> [-i <instructions>]"
+allowed-tools: Bash(zerogpu chat *)
 ---
 
 Call qwen3-30b-a3b-fp8. `$ARGUMENTS` is the raw prompt — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
@@ -12,10 +12,11 @@ ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
 $ARGUMENTS
 ZGPU_END_OF_INPUT
 )
-export ZGPU_TEXT
-node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}fetch("https://api.zerogpu.ai/v1/chat/completions",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"qwen3-30b-a3b-fp8",messages:[{role:"user",content:process.env.ZGPU_TEXT}]})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const c=d.choices&&d.choices[0]&&d.choices[0].message&&d.choices[0].message.content;console.log(c?c.trim():JSON.stringify(d,null,2))}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+zerogpu chat "$ZGPU_TEXT" -m qwen3-30b-a3b-fp8
 ```
 
-This model is served on Chat Completions only — the Responses endpoint is not available for it. Output is the assistant's answer as plain text; the model's separate reasoning field is deliberately dropped. Relay the answer as-is — do not rewrite or expand it.
+If the user supplied system instructions, append `-i "<instructions>"` after the model flag.
 
-This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in `/zerogpu-router:cost-savings`.
+This model is served by the Chat Completions API rather than the Responses API; the CLI routes it automatically. Output is the assistant's answer as plain text — the model's reasoning trace is omitted, since this skill does not pass the CLI's `-r` flag. Relay the answer as-is — do not rewrite or expand it.
+
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest `/zerogpu-router:cost-savings` — this note is intentionally occasional, not shown every time.

--- a/agents/claude/skills/classify-domain/SKILL.md
+++ b/agents/claude/skills/classify-domain/SKILL.md
@@ -1,23 +1,20 @@
 ---
 name: classify-domain
 description: Classify a domain name against the IAB taxonomy without fetching the page (zlm-v1-iab-domain-classifier). Use when the user has a hostname or URL rather than article text — bidstream enrichment, allow/deny-list scoring, "what is example.com about?".
-argument-hint: "<domain-or-url>"
-allowed-tools: Bash(node -e *)
+argument-hint: "<domain>"
+allowed-tools: Bash(zerogpu classify_domain*)
 ---
 
-Classify a domain. `$ARGUMENTS` is the domain or URL — pass it verbatim. Full URLs are normalized down to the hostname, so `https://www.nytimes.com/section/world?x=1` works as well as `nytimes.com`:
+Classify a domain:
 
 ```!
-ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
-$ARGUMENTS
-ZGPU_END_OF_INPUT
-)
-export ZGPU_TEXT
-node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}const dom=(process.env.ZGPU_TEXT||"").trim().replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//,"").split(/[\/?#]/)[0].toLowerCase();if(!dom){console.error("No domain supplied.");process.exit(1)}fetch("https://api.zerogpu.ai/v1/responses",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"zlm-v1-iab-domain-classifier",input:dom})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const m=(d.output||[]).find(o=>o.type==="message");const t=m&&(m.content||[]).find(c=>c.type==="output_text");if(!t){console.log(JSON.stringify(d,null,2));return}try{console.log(JSON.stringify(JSON.parse(t.text),null,2))}catch(e){console.log(t.text)}}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+zerogpu classify_domain "$ARGUMENTS"
 ```
+
+**Format `$ARGUMENTS` as a bare hostname.** The model takes only the domain — strip the scheme, path, query, and fragment first. `https://www.nytimes.com/section/world?x=1` becomes `www.nytimes.com`. If the user gave you several domains, run the command once per domain.
 
 Output is a JSON object with `audience` (IAB 2.2 audience tiers with scores) and `content` (`iab_1_0` and `iab_2_2` category lists).
 
-Use this instead of `/zerogpu-router:classify-iab` when the input is a domain — it needs only the hostname, so payloads are up to 10x smaller than sending page text. If the user has actual article text, use `classify-iab` or `classify-iab-enriched`.
+Use this instead of `/zerogpu-router:classify-iab` when the input is a domain — it needs only the hostname, so payloads are up to 10x smaller than sending page text. If the user has the actual article text and wants per-URL precision, use `classify-iab` or `classify-iab-enriched`.
 
-This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in `/zerogpu-router:cost-savings`.
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest `/zerogpu-router:cost-savings` — this note is intentionally occasional, not shown every time.

--- a/agents/claude/skills/classify-domain/SKILL.md
+++ b/agents/claude/skills/classify-domain/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: classify-domain
+description: Classify a domain name against the IAB taxonomy without fetching the page (zlm-v1-iab-domain-classifier). Use when the user has a hostname or URL rather than article text — bidstream enrichment, allow/deny-list scoring, "what is example.com about?".
+argument-hint: "<domain-or-url>"
+allowed-tools: Bash(node -e *)
+---
+
+Classify a domain. `$ARGUMENTS` is the domain or URL — pass it verbatim. Full URLs are normalized down to the hostname, so `https://www.nytimes.com/section/world?x=1` works as well as `nytimes.com`:
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+export ZGPU_TEXT
+node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}const dom=(process.env.ZGPU_TEXT||"").trim().replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//,"").split(/[\/?#]/)[0].toLowerCase();if(!dom){console.error("No domain supplied.");process.exit(1)}fetch("https://api.zerogpu.ai/v1/responses",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"zlm-v1-iab-domain-classifier",input:dom})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const m=(d.output||[]).find(o=>o.type==="message");const t=m&&(m.content||[]).find(c=>c.type==="output_text");if(!t){console.log(JSON.stringify(d,null,2));return}try{console.log(JSON.stringify(JSON.parse(t.text),null,2))}catch(e){console.log(t.text)}}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+```
+
+Output is a JSON object with `audience` (IAB 2.2 audience tiers with scores) and `content` (`iab_1_0` and `iab_2_2` category lists).
+
+Use this instead of `/zerogpu-router:classify-iab` when the input is a domain — it needs only the hostname, so payloads are up to 10x smaller than sending page text. If the user has actual article text, use `classify-iab` or `classify-iab-enriched`.
+
+This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in `/zerogpu-router:cost-savings`.

--- a/agents/claude/skills/generate-followups/SKILL.md
+++ b/agents/claude/skills/generate-followups/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: generate-followups
+description: Generate natural follow-up questions a reader would ask next about a passage (zlm-v1-followup-questions-edge). Use when the user wants suggested next questions, "people also ask" style prompts, or conversation continuations for an article, answer, or chat turn.
+argument-hint: "<text>"
+allowed-tools: Bash(zerogpu generate_followups*)
+---
+
+Generate follow-up questions. `$ARGUMENTS` is the raw source text — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+zerogpu generate_followups "$ZGPU_TEXT"
+```
+
+Output is a JSON array of question strings. Relay them as-is — do not rewrite, reorder, or add your own questions.
+
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest `/zerogpu-router:cost-savings` — this note is intentionally occasional, not shown every time.

--- a/agents/openclaw/CHANGELOG.md
+++ b/agents/openclaw/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 3.1.0
+
+Catches the plugin up to the [ZeroGPU model catalog](https://docs.zerogpu.ai/docs/model-catalog), which added three models and renamed a fourth. **Four new skills; the existing 14 are unchanged.**
+
+### Added
+
+- `generate-followups` — suggested next questions for a passage, "people also ask" style. Model `zlm-v1-followup-questions-edge`, wrapping `zerogpu generate_followups`. The CLI has shipped this command since 3.1.0; the plugin never exposed it.
+- `classify-domain` — IAB classification from a bare hostname, no page fetch. Model `zlm-v1-iab-domain-classifier`. Full URLs are normalized down to the hostname, so `https://www.nytimes.com/section/world?x=1` and `nytimes.com` behave identically. Payloads run up to 10x smaller than sending page text, which is the point for bidstream enrichment and allow/deny-list scoring.
+- `chat-gpt-oss` — heavier chat via `gpt-oss-120b` (117B MoE, 131,072-token context) for long documents and multi-step instructions the 1.2B edge models can't carry.
+- `chat-qwen` — heavier multilingual chat via `qwen3-30b-a3b-fp8` (30.5B MoE, 100+ languages). This model is served on Chat Completions only, so the skill posts to `/v1/chat/completions` rather than `/v1/responses`.
+
+Both chat models return an internal reasoning trace. The skills deliberately drop it and print only the final answer, matching how `chat` behaves — `chat-thinking` remains the skill that surfaces reasoning.
+
+### Changed
+
+- `classify-iab-enriched` — documented model renamed `zlm-v1-iab-classify-edge-enriched` → `zlm-v2-iab-classify-edge-enriched`, following the catalog. No behavior change: the skill still shells out to `zerogpu classify_iab_enriched`, and the API resolves both ids to the same model.
+- `plugin/README.md` — skills table covers all 18 skills; the "Data & privacy" section now distinguishes skills that transmit via the CLI from the three that post to the API directly.
+- The three direct-API skills declare `bins: [zerogpu, node]` in their OpenClaw `requires` metadata. `node` was already an implicit prerequisite (it runs the CLI); it is now explicit for the skills that depend on it directly.
+
+### Known limitation
+
+`classify-domain`, `chat-gpt-oss`, and `chat-qwen` call `https://api.zerogpu.ai` directly, because `zerogpu-cli` (3.2.0, current) has no command for these three models. They read the same credentials — `~/.zerogpu/config.json`, falling back to `$ZEROGPU_API_KEY` — and fail with the same "run `zerogpu login`" message when unauthenticated, but since the CLI isn't in the call path it can't record the call: **these three do not contribute to the `cost-savings` skill**. The other 15 skills are unaffected. When the CLI adds commands for these models, the skills move onto it and start counting.
+
 ## 3.0.1
 
 Fixes a gateway boot failure on OpenClaw `2026.7.1`. Installs of this plugin could leave the gateway

--- a/agents/openclaw/CHANGELOG.md
+++ b/agents/openclaw/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 3.1.0
 
-Catches the plugin up to the [ZeroGPU model catalog](https://docs.zerogpu.ai/docs/model-catalog), which added three models and renamed a fourth, and to `zerogpu-cli` 3.3.0, which added the commands to reach them. **Four new skills; the existing 14 are unchanged.**
+Catches the plugin up to the [ZeroGPU model catalog](https://docs.zerogpu.ai/docs/model-catalog), which added three models and renamed a fourth, and to `zerogpu-cli` 3.3.0, which added the commands to reach them. **Four new skills; the existing 14 are unchanged.** Also a rewritten ClawHub listing.
 
-Requires `zerogpu-cli` **≥ 3.3.0** for the three new model skills — `chat --model` and `classify_domain` landed in that release. The other 15 skills still work on any 3.x.
+Keep the CLI current — `npm install -g zerogpu-cli@latest` — and every skill works.
 
 ### Added
 
@@ -20,7 +20,10 @@ Savings tracking covers all four: every call goes through the CLI, and 3.3.0 pri
 ### Changed
 
 - `classify-iab-enriched` — documented model renamed `zlm-v1-iab-classify-edge-enriched` → `zlm-v2-iab-classify-edge-enriched`, following the catalog and CLI 3.3.0. No behavior change: the skill still shells out to `zerogpu classify_iab_enriched`.
-- `plugin/README.md` — skills table covers all 18 skills, and notes the `zerogpu-cli` ≥ 3.3.0 floor for the three new model skills.
+- **`plugin/README.md` rewritten for the ClawHub listing.** Leads on the positioning that matters — open-weight and small language models, OpenAI-compatible APIs, pay-as-you-go, and a catalog growing by roughly a model a day. Adds a topic-tag row and badges for docs, API compatibility, and pricing alongside the existing website/dashboard/license badges, matching how established ClawHub plugins present themselves. The 18 skills are now grouped into Classification, Extraction & PII, Generation, and Account tables instead of one flat list, and Links became a Support table with docs and issues rows.
+- **Plugin description** (`openclaw.plugin.json`, `plugin/package.json`) — "trivial AI tasks … small/nano models" reworded to "your AI tasks … open-weight and small language models", noting OpenAI compatibility and pay-as-you-go pricing. This is the copy ClawHub shows on the plugin card.
+- **Package keywords** — added `open-weight-models`, `small-language-models`, `openai-compatible`, `classification`, `pii-redaction`, and `summarization`. ClawHub renders these as the listing's topic tags, so the plugin now surfaces for those searches.
+- **No version pinning in the docs.** Dropped the stale `clawhub:zerogpu-router@2.0.0` pin example and the `zerogpu-cli` ≥ 3.3.0 floor callout; install guidance is now simply `zerogpu-cli@latest`. Functionally unchanged — the three new model skills still need the CLI release that carries `chat --model` and `classify_domain`, users just aren't asked to track version numbers.
 
 ## 3.0.1
 

--- a/agents/openclaw/CHANGELOG.md
+++ b/agents/openclaw/CHANGELOG.md
@@ -2,26 +2,25 @@
 
 ## 3.1.0
 
-Catches the plugin up to the [ZeroGPU model catalog](https://docs.zerogpu.ai/docs/model-catalog), which added three models and renamed a fourth. **Four new skills; the existing 14 are unchanged.**
+Catches the plugin up to the [ZeroGPU model catalog](https://docs.zerogpu.ai/docs/model-catalog), which added three models and renamed a fourth, and to `zerogpu-cli` 3.3.0, which added the commands to reach them. **Four new skills; the existing 14 are unchanged.**
+
+Requires `zerogpu-cli` **≥ 3.3.0** for the three new model skills — `chat --model` and `classify_domain` landed in that release. The other 15 skills still work on any 3.x.
 
 ### Added
 
 - `generate-followups` — suggested next questions for a passage, "people also ask" style. Model `zlm-v1-followup-questions-edge`, wrapping `zerogpu generate_followups`. The CLI has shipped this command since 3.1.0; the plugin never exposed it.
-- `classify-domain` — IAB classification from a bare hostname, no page fetch. Model `zlm-v1-iab-domain-classifier`. Full URLs are normalized down to the hostname, so `https://www.nytimes.com/section/world?x=1` and `nytimes.com` behave identically. Payloads run up to 10x smaller than sending page text, which is the point for bidstream enrichment and allow/deny-list scoring.
-- `chat-gpt-oss` — heavier chat via `gpt-oss-120b` (117B MoE, 131,072-token context) for long documents and multi-step instructions the 1.2B edge models can't carry.
-- `chat-qwen` — heavier multilingual chat via `qwen3-30b-a3b-fp8` (30.5B MoE, 100+ languages). This model is served on Chat Completions only, so the skill posts to `/v1/chat/completions` rather than `/v1/responses`.
+- `classify-domain` — IAB classification from a bare hostname, no page fetch. Model `zlm-v1-iab-domain-classifier`, wrapping `zerogpu classify_domain`. Payloads run up to 10x smaller than sending page text, which is the point for bidstream enrichment and allow/deny-list scoring. The agent strips the scheme, path, and query before calling, so pasting a full URL works.
+- `chat-gpt-oss` — heavier chat via `gpt-oss-120b` (117B MoE, 131,072-token context) for long documents and multi-step instructions the 1.2B edge models can't carry. Wraps `zerogpu chat -m gpt-oss-120b`.
+- `chat-qwen` — heavier multilingual chat via `qwen3-30b-a3b-fp8` (30.5B MoE, 100+ languages). Wraps `zerogpu chat -m qwen3-30b-a3b-fp8`; this model is served by the Chat Completions API rather than the Responses API, which the CLI handles.
 
-Both chat models return an internal reasoning trace. The skills deliberately drop it and print only the final answer, matching how `chat` behaves — `chat-thinking` remains the skill that surfaces reasoning.
+Both new chat models return a reasoning trace. Neither skill passes the CLI's `-r` flag, so only the final answer is printed — matching how `chat` behaves. `chat-thinking` remains the skill that surfaces reasoning.
+
+Savings tracking covers all four: every call goes through the CLI, and 3.3.0 prices each of these models in its savings table, so they contribute to the `cost-savings` skill like any other.
 
 ### Changed
 
-- `classify-iab-enriched` — documented model renamed `zlm-v1-iab-classify-edge-enriched` → `zlm-v2-iab-classify-edge-enriched`, following the catalog. No behavior change: the skill still shells out to `zerogpu classify_iab_enriched`, and the API resolves both ids to the same model.
-- `plugin/README.md` — skills table covers all 18 skills; the "Data & privacy" section now distinguishes skills that transmit via the CLI from the three that post to the API directly.
-- The three direct-API skills declare `bins: [zerogpu, node]` in their OpenClaw `requires` metadata. `node` was already an implicit prerequisite (it runs the CLI); it is now explicit for the skills that depend on it directly.
-
-### Known limitation
-
-`classify-domain`, `chat-gpt-oss`, and `chat-qwen` call `https://api.zerogpu.ai` directly, because `zerogpu-cli` (3.2.0, current) has no command for these three models. They read the same credentials — `~/.zerogpu/config.json`, falling back to `$ZEROGPU_API_KEY` — and fail with the same "run `zerogpu login`" message when unauthenticated, but since the CLI isn't in the call path it can't record the call: **these three do not contribute to the `cost-savings` skill**. The other 15 skills are unaffected. When the CLI adds commands for these models, the skills move onto it and start counting.
+- `classify-iab-enriched` — documented model renamed `zlm-v1-iab-classify-edge-enriched` → `zlm-v2-iab-classify-edge-enriched`, following the catalog and CLI 3.3.0. No behavior change: the skill still shells out to `zerogpu classify_iab_enriched`.
+- `plugin/README.md` — skills table covers all 18 skills, and notes the `zerogpu-cli` ≥ 3.3.0 floor for the three new model skills.
 
 ## 3.0.1
 

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -44,4 +44,4 @@ See [./plugin/README.md](./plugin/README.md) — the single source of truth for 
 ## Notes
 
 - No additional infrastructure or services required.
-- Skills run locally through the `zerogpu` CLI.
+- Most skills run locally through the `zerogpu` CLI. `classify-domain`, `chat-gpt-oss`, and `chat-qwen` call the ZeroGPU API directly with the same saved credentials, because the CLI has no command for those models yet — so their usage isn't counted in `cost-savings`.

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -1,13 +1,13 @@
 # OpenClaw Integration
 
-Use ZeroGPU Router with your OpenClaw agent to route routine AI tasks to small models and cut inference costs. This page is a quick entry point — see the plugin README for the full guide.
+Use ZeroGPU Router with your OpenClaw agent to route your AI tasks to open-weight and small language models and cut inference costs. This page is a quick entry point — see the plugin README for the full guide.
 
 ## Quick start
 
 Get an API key at [platform.zerogpu.ai](https://platform.zerogpu.ai), then:
 
 ```sh
-npm install -g zerogpu-cli                        # the CLI the skills shell out to
+npm install -g zerogpu-cli@latest                 # the CLI the skills shell out to
 zerogpu login                                     # prompts for your API key
 openclaw plugins install clawhub:zerogpu-router
 ```
@@ -44,4 +44,4 @@ See [./plugin/README.md](./plugin/README.md) — the single source of truth for 
 ## Notes
 
 - No additional infrastructure or services required.
-- Skills run locally through the `zerogpu` CLI. `chat-gpt-oss`, `chat-qwen`, and `classify-domain` require CLI **≥ 3.3.0**.
+- Skills run locally through the `zerogpu` CLI — keep it current with `npm install -g zerogpu-cli@latest`.

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -44,4 +44,4 @@ See [./plugin/README.md](./plugin/README.md) — the single source of truth for 
 ## Notes
 
 - No additional infrastructure or services required.
-- Most skills run locally through the `zerogpu` CLI. `classify-domain`, `chat-gpt-oss`, and `chat-qwen` call the ZeroGPU API directly with the same saved credentials, because the CLI has no command for those models yet — so their usage isn't counted in `cost-savings`.
+- Skills run locally through the `zerogpu` CLI. `chat-gpt-oss`, `chat-qwen`, and `classify-domain` require CLI **≥ 3.3.0**.

--- a/agents/openclaw/plugin/README.md
+++ b/agents/openclaw/plugin/README.md
@@ -1,18 +1,28 @@
 # ZeroGPU Router
 
-Cut your OpenClaw agent's inference costs. Route trivial AI tasks — summarize, classify, redact PII, extract JSON, short chat — to small/nano models instead of burning frontier-model tokens.
+**Cut your OpenClaw agent's inference costs.** Route your AI tasks — summarize, classify, redact PII, extract JSON, short chat — to open-weight and small language models instead of burning frontier-model tokens. Our APIs are OpenAI-compatible and pay-as-you-go.
 
 [![Website](https://img.shields.io/badge/website-zerogpu.ai-22c55e)](https://zerogpu.ai)
-[![Dashboard](https://img.shields.io/badge/dashboard-platform.zerogpu.ai-blue)](https://platform.zerogpu.ai)
-[![License](https://img.shields.io/badge/license-MIT-yellow)](https://github.com/zerogpu/zerogpu-router/blob/main/LICENSE)
+[![Dashboard](https://img.shields.io/badge/dashboard-platform.zerogpu.ai-3b82f6)](https://platform.zerogpu.ai)
+[![Docs](https://img.shields.io/badge/docs-docs.zerogpu.ai-8b5cf6)](https://docs.zerogpu.ai)
+[![OpenAI compatible](https://img.shields.io/badge/API-OpenAI--compatible-000000)](https://docs.zerogpu.ai/api-reference/chat-completions)
+[![Pricing](https://img.shields.io/badge/pricing-pay--as--you--go-f59e0b)](https://docs.zerogpu.ai/docs/model-catalog)
+[![License](https://img.shields.io/badge/license-MIT-eab308)](https://github.com/zerogpu/zerogpu-router/blob/main/LICENSE)
+
+`#cost-optimization` `#model-routing` `#open-weight-models` `#small-language-models` `#classification` `#pii-redaction` `#summarization` `#openai-compatible`
+
+---
 
 ## What it does
 
-Your OpenClaw agent keeps doing the heavy reasoning. Routine tasks get offloaded to ZeroGPU's small models — typically 100–1000× cheaper per call.
+Your OpenClaw agent keeps doing the heavy reasoning. Routine tasks get offloaded to ZeroGPU's open-weight and small models — typically **100–1000× cheaper per call**.
 
-- Task-specific skills (`summarize`, `classify-iab`, `redact-pii`, …)
-- Each skill shells out to the local `zerogpu` CLI via the agent's Bash tools — nothing to host or register
-- Per-call savings logged with model, latency, and a real `savings_usd` figure
+Our open-weight models are the most cost-effective on the market right now. You'll find models here you won't see anywhere else, and we add roughly one a day.
+
+- **18 task-specific skills** — `summarize`, `classify-iab`, `redact-pii`, `extract-json`, and more
+- **Nothing to host or register** — each skill shells out to the local `zerogpu` CLI through the agent's Bash tools
+- **Savings you can see** — every call logs its model, usage, and a real dollar figure
+- **OpenAI-compatible, pay-as-you-go** — no commitments, no idle GPU cost
 
 ## Quickstart
 
@@ -20,18 +30,16 @@ Get an API key at [platform.zerogpu.ai](https://platform.zerogpu.ai), then:
 
 ```bash
 # 1. Install the CLI the skills shell out to
-npm install -g zerogpu-cli
+npm install -g zerogpu-cli@latest
 
-# 2. Log in (prompts for API key)
+# 2. Log in (prompts for your API key)
 zerogpu login
 
 # 3. Install the plugin
 openclaw plugins install clawhub:zerogpu-router
 ```
 
-Pin a release: `clawhub:zerogpu-router@2.0.0`.
-
-> Every skill shells out to the `zerogpu` CLI — install it globally and run a one-time
+> Every skill shells out to the `zerogpu` CLI, so install it globally and run a one-time
 > `zerogpu login` before using the plugin. In sandboxed/Docker agents, make sure `zerogpu`
 > is available inside the container.
 
@@ -110,30 +118,45 @@ Note the card last-four is left untouched — the PII model covers standard cate
 
 ## The skills you get
 
+**Classification**
+
 | Skill | Workload | Backing model |
 |---|---|---|
 | `classify-iab` | IAB topic classification | `zlm-v1-iab-classify-edge` |
 | `classify-iab-enriched` | IAB categories plus topics, keywords, intent | `zlm-v2-iab-classify-edge-enriched` |
 | `classify-domain` | IAB classification from a bare hostname, no page fetch | `zlm-v1-iab-domain-classifier` |
-| `summarize` | TL;DRs, abstracts, meeting summaries | `llama-3.1-8b-instruct-fast` |
 | `classify-zero-shot` | Classify against a flat label list | `deberta-v3-small` |
 | `classify-structured` | Multi-axis schema classification | `gliner2-base-v1` |
-| `extract-entities` | People, places, companies, dates, custom entities | `gliner2-base-v1` |
-| `extract-json` | Pull structured fields into grouped JSON | `gliner2-base-v1` |
+
+**Extraction & PII**
+
+| Skill | Workload | Backing model |
+|---|---|---|
 | `redact-pii` | Mask emails, phones, names, addresses, other PII | `gliner-multi-pii-v1` |
 | `extract-pii` | Extract PII grouped by category | `gliner-multi-pii-v1` |
+| `extract-entities` | People, places, companies, dates, custom entities | `gliner2-base-v1` |
+| `extract-json` | Pull structured fields into grouped JSON | `gliner2-base-v1` |
+
+**Generation**
+
+| Skill | Workload | Backing model |
+|---|---|---|
+| `summarize` | TL;DRs, abstracts, meeting summaries | `llama-3.1-8b-instruct-fast` |
 | `generate-followups` | Suggested next questions for a passage | `zlm-v1-followup-questions-edge` |
 | `chat` | Short small-model chat replies | `LFM2.5-1.2B-Instruct` |
 | `chat-thinking` | Short chat replies with a visible reasoning trace | `LFM2.5-1.2B-Thinking` |
 | `chat-gpt-oss` | Heavier chat: long context, multi-step instructions | `gpt-oss-120b` |
 | `chat-qwen` | Heavier chat: multilingual, 100+ languages | `qwen3-30b-a3b-fp8` |
-| `cost-savings` | Cumulative dollars and tokens offloaded to ZeroGPU | — |
-| `signin` | Sign in and persist API key | — |
-| `status` | Show current sign-in status | — |
 
-Every skill returns `{ <task fields>, model, usage, savings }`.
+**Account**
 
-`chat-gpt-oss`, `chat-qwen`, and `classify-domain` require **`zerogpu-cli` ≥ 3.3.0** — that release added `chat --model` and the `classify_domain` command. Run `npm install -g zerogpu-cli@latest` if those three fail; the rest work on any 3.x.
+| Skill | Workload |
+|---|---|
+| `cost-savings` | Cumulative dollars and tokens offloaded to ZeroGPU |
+| `signin` | Sign in and persist API key |
+| `status` | Show current sign-in status |
+
+Every skill returns `{ <task fields>, model, usage, savings }`. Browse the full catalog with pricing at [docs.zerogpu.ai](https://docs.zerogpu.ai/docs/model-catalog).
 
 ## Watch your savings
 
@@ -151,13 +174,17 @@ Before using these skills:
 
 **Credentials:** `zerogpu login` (the `signin` skill) writes your API key to a local config file and upserts `ZEROGPU_API_KEY` into your shell profile — a persistent change to your environment. Revoke keys from the [dashboard](https://platform.zerogpu.ai).
 
-## Links
+## Support
 
-- Website: <https://zerogpu.ai>
-- Dashboard: <https://platform.zerogpu.ai>
-- Source: <https://github.com/zerogpu/zerogpu-router>
-- Full setup guide: <https://github.com/zerogpu/zerogpu-router/tree/main/agents/openclaw>
-- Issues / contact: <hello@zerogpu.ai>
+| | |
+|---|---|
+| Website | <https://zerogpu.ai> |
+| Docs | <https://docs.zerogpu.ai> |
+| Dashboard | <https://platform.zerogpu.ai> |
+| Source | <https://github.com/zerogpu/zerogpu-router> |
+| Setup guide | <https://github.com/zerogpu/zerogpu-router/tree/main/agents/openclaw> |
+| Issues | <https://github.com/zerogpu/zerogpu-router/issues> |
+| Contact | <hello@zerogpu.ai> |
 
 ## License
 

--- a/agents/openclaw/plugin/README.md
+++ b/agents/openclaw/plugin/README.md
@@ -113,7 +113,8 @@ Note the card last-four is left untouched — the PII model covers standard cate
 | Skill | Workload | Backing model |
 |---|---|---|
 | `classify-iab` | IAB topic classification | `zlm-v1-iab-classify-edge` |
-| `classify-iab-enriched` | IAB categories plus topics, keywords, intent | `zlm-v1-iab-classify-edge-enriched` |
+| `classify-iab-enriched` | IAB categories plus topics, keywords, intent | `zlm-v2-iab-classify-edge-enriched` |
+| `classify-domain` | IAB classification from a bare hostname, no page fetch | `zlm-v1-iab-domain-classifier` |
 | `summarize` | TL;DRs, abstracts, meeting summaries | `llama-3.1-8b-instruct-fast` |
 | `classify-zero-shot` | Classify against a flat label list | `deberta-v3-small` |
 | `classify-structured` | Multi-axis schema classification | `gliner2-base-v1` |
@@ -121,13 +122,18 @@ Note the card last-four is left untouched — the PII model covers standard cate
 | `extract-json` | Pull structured fields into grouped JSON | `gliner2-base-v1` |
 | `redact-pii` | Mask emails, phones, names, addresses, other PII | `gliner-multi-pii-v1` |
 | `extract-pii` | Extract PII grouped by category | `gliner-multi-pii-v1` |
+| `generate-followups` | Suggested next questions for a passage | `zlm-v1-followup-questions-edge` |
 | `chat` | Short small-model chat replies | `LFM2.5-1.2B-Instruct` |
 | `chat-thinking` | Short chat replies with a visible reasoning trace | `LFM2.5-1.2B-Thinking` |
+| `chat-gpt-oss` | Heavier chat: long context, multi-step instructions | `gpt-oss-120b` |
+| `chat-qwen` | Heavier chat: multilingual, 100+ languages | `qwen3-30b-a3b-fp8` |
 | `cost-savings` | Cumulative dollars and tokens offloaded to ZeroGPU | — |
 | `signin` | Sign in and persist API key | — |
 | `status` | Show current sign-in status | — |
 
 Every skill returns `{ <task fields>, model, usage, savings }`.
+
+**Three skills call the ZeroGPU API directly.** `classify-domain`, `chat-gpt-oss`, and `chat-qwen` cover models the `zerogpu` CLI has no command for, so they POST to `api.zerogpu.ai` themselves using the credentials `zerogpu login` saved (`~/.zerogpu/config.json`, or `ZEROGPU_API_KEY`). They need `node` on your `PATH` — already a prerequisite for the CLI. Because they bypass the CLI, **their usage is not counted in `cost-savings`**; the other skills are unaffected.
 
 ## Watch your savings
 
@@ -135,7 +141,7 @@ Live dashboard at **[platform.zerogpu.ai](https://platform.zerogpu.ai)** — tok
 
 ## Data & privacy
 
-**These skills are not local processing.** Every content skill (`summarize`, `classify-*`, `extract-*`, `redact-pii`, `extract-pii`, `chat`, `chat-thinking`) passes the text you supply to the local `zerogpu` CLI, which transmits it over the network to ZeroGPU's hosted models. The CLI runs locally; the inference does not.
+**These skills are not local processing.** Every content skill (`summarize`, `classify-*`, `extract-*`, `redact-pii`, `extract-pii`, `generate-followups`, `chat`, `chat-thinking`) passes the text you supply to the local `zerogpu` CLI, which transmits it over the network to ZeroGPU's hosted models. `classify-domain`, `chat-gpt-oss`, and `chat-qwen` transmit it to the same hosted API directly, without the CLI in between. Either way the code runs locally; the inference does not.
 
 Before using these skills:
 

--- a/agents/openclaw/plugin/README.md
+++ b/agents/openclaw/plugin/README.md
@@ -133,7 +133,7 @@ Note the card last-four is left untouched — the PII model covers standard cate
 
 Every skill returns `{ <task fields>, model, usage, savings }`.
 
-**Three skills call the ZeroGPU API directly.** `classify-domain`, `chat-gpt-oss`, and `chat-qwen` cover models the `zerogpu` CLI has no command for, so they POST to `api.zerogpu.ai` themselves using the credentials `zerogpu login` saved (`~/.zerogpu/config.json`, or `ZEROGPU_API_KEY`). They need `node` on your `PATH` — already a prerequisite for the CLI. Because they bypass the CLI, **their usage is not counted in `cost-savings`**; the other skills are unaffected.
+`chat-gpt-oss`, `chat-qwen`, and `classify-domain` require **`zerogpu-cli` ≥ 3.3.0** — that release added `chat --model` and the `classify_domain` command. Run `npm install -g zerogpu-cli@latest` if those three fail; the rest work on any 3.x.
 
 ## Watch your savings
 
@@ -141,7 +141,7 @@ Live dashboard at **[platform.zerogpu.ai](https://platform.zerogpu.ai)** — tok
 
 ## Data & privacy
 
-**These skills are not local processing.** Every content skill (`summarize`, `classify-*`, `extract-*`, `redact-pii`, `extract-pii`, `generate-followups`, `chat`, `chat-thinking`) passes the text you supply to the local `zerogpu` CLI, which transmits it over the network to ZeroGPU's hosted models. `classify-domain`, `chat-gpt-oss`, and `chat-qwen` transmit it to the same hosted API directly, without the CLI in between. Either way the code runs locally; the inference does not.
+**These skills are not local processing.** Every content skill (`summarize`, `classify-*`, `extract-*`, `redact-pii`, `extract-pii`, `generate-followups`, `chat`, `chat-thinking`, `chat-gpt-oss`, `chat-qwen`) passes the text you supply to the local `zerogpu` CLI, which transmits it over the network to ZeroGPU's hosted models. The CLI runs locally; the inference does not.
 
 Before using these skills:
 

--- a/agents/openclaw/plugin/openclaw.plugin.json
+++ b/agents/openclaw/plugin/openclaw.plugin.json
@@ -6,7 +6,10 @@
   "version": "3.0.1",
   "skills": [
     "./skills/chat",
+    "./skills/chat-gpt-oss",
+    "./skills/chat-qwen",
     "./skills/chat-thinking",
+    "./skills/classify-domain",
     "./skills/classify-iab",
     "./skills/classify-iab-enriched",
     "./skills/classify-structured",
@@ -15,6 +18,7 @@
     "./skills/extract-entities",
     "./skills/extract-json",
     "./skills/extract-pii",
+    "./skills/generate-followups",
     "./skills/redact-pii",
     "./skills/signin",
     "./skills/status",

--- a/agents/openclaw/plugin/openclaw.plugin.json
+++ b/agents/openclaw/plugin/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "zerogpu-router",
   "name": "ZeroGPU Router",
-  "description": "Route trivial AI tasks (classification, summarization, extraction, PII redaction, small-model chat) to ZeroGPU small/nano models via ZeroGPU CLI.",
+  "description": "Route your AI tasks (classification, summarization, extraction, PII redaction, chat) to ZeroGPU's open-weight and small language models via the ZeroGPU CLI. OpenAI-compatible and pay-as-you-go.",
   "icon": "https://avatars.githubusercontent.com/u/242287374?v=4",
   "version": "3.0.1",
   "skills": [

--- a/agents/openclaw/plugin/package.json
+++ b/agents/openclaw/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zerogpu-router",
   "version": "3.0.1",
-  "description": "ZeroGPU Router plugin for OpenClaw: route trivial AI tasks (summarize, classify, redact PII, extract JSON) to small/nano models via the zerogpu CLI. Cuts agent inference costs without changing your reasoning model.",
+  "description": "ZeroGPU Router plugin for OpenClaw: route your AI tasks (summarize, classify, redact PII, extract JSON, chat) to open-weight and small language models via the zerogpu CLI. OpenAI-compatible and pay-as-you-go — cuts agent inference costs without changing your reasoning model.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,10 +28,16 @@
   "keywords": [
     "openclaw",
     "openclaw-plugin",
+    "agent-plugin",
     "zerogpu",
-    "model-routing",
     "cost-optimization",
-    "agent-plugin"
+    "model-routing",
+    "open-weight-models",
+    "small-language-models",
+    "openai-compatible",
+    "classification",
+    "pii-redaction",
+    "summarization"
   ],
   "publishConfig": {
     "access": "public"

--- a/agents/openclaw/plugin/skills/chat-gpt-oss/SKILL.md
+++ b/agents/openclaw/plugin/skills/chat-gpt-oss/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: chat-gpt-oss
 description: Chat with gpt-oss-120b, ZeroGPU's largest open-weight model (117B MoE, 131K context). Use when a task needs more capability than the 1.2B edge models can give — longer documents, multi-step instructions, harder general-knowledge questions — but still does not warrant the host model.
-argument-hint: "<text>"
-allowed-tools: Bash(node -e *)
+argument-hint: "<text> [-i <instructions>]"
+allowed-tools: Bash(zerogpu chat *)
 metadata:
   openclaw:
     requires:
-      bins: [zerogpu, node]
+      bins: [zerogpu]
     install:
       - kind: node
         package: zerogpu-cli
@@ -22,10 +22,11 @@ ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
 $ARGUMENTS
 ZGPU_END_OF_INPUT
 )
-export ZGPU_TEXT
-node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}fetch("https://api.zerogpu.ai/v1/responses",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"gpt-oss-120b",input:process.env.ZGPU_TEXT})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const m=(d.output||[]).find(o=>o.type==="message");const t=m&&(m.content||[]).find(c=>c.type==="output_text");console.log(t?t.text:JSON.stringify(d,null,2))}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+zerogpu chat "$ZGPU_TEXT" -m gpt-oss-120b
 ```
 
-Output is the assistant's answer as plain text. The model also produces an internal reasoning trace; the command above deliberately drops it and prints only the final answer. Relay that answer as-is — do not rewrite or expand it.
+If the user supplied system instructions, append `-i "<instructions>"` after the model flag.
 
-This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in the `cost-savings` skill.
+Output is the assistant's answer as plain text. The model also produces a reasoning trace; this skill omits the CLI's `-r` flag so only the final answer is printed. Relay that answer as-is — do not rewrite or expand it.
+
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest the `cost-savings` skill — this note is intentionally occasional, not shown every time.

--- a/agents/openclaw/plugin/skills/chat-gpt-oss/SKILL.md
+++ b/agents/openclaw/plugin/skills/chat-gpt-oss/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: chat-gpt-oss
+description: Chat with gpt-oss-120b, ZeroGPU's largest open-weight model (117B MoE, 131K context). Use when a task needs more capability than the 1.2B edge models can give — longer documents, multi-step instructions, harder general-knowledge questions — but still does not warrant the host model.
+argument-hint: "<text>"
+allowed-tools: Bash(node -e *)
+metadata:
+  openclaw:
+    requires:
+      bins: [zerogpu, node]
+    install:
+      - kind: node
+        package: zerogpu-cli
+        bins: [zerogpu]
+---
+
+> **Sends your input to ZeroGPU's hosted API** for inference — this is not local processing. Don't pass secrets, credentials, or regulated data you aren't cleared to share with a third party. See the plugin README's "Data & privacy" section.
+
+Call gpt-oss-120b. `$ARGUMENTS` is the raw prompt — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+export ZGPU_TEXT
+node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}fetch("https://api.zerogpu.ai/v1/responses",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"gpt-oss-120b",input:process.env.ZGPU_TEXT})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const m=(d.output||[]).find(o=>o.type==="message");const t=m&&(m.content||[]).find(c=>c.type==="output_text");console.log(t?t.text:JSON.stringify(d,null,2))}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+```
+
+Output is the assistant's answer as plain text. The model also produces an internal reasoning trace; the command above deliberately drops it and prints only the final answer. Relay that answer as-is — do not rewrite or expand it.
+
+This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in the `cost-savings` skill.

--- a/agents/openclaw/plugin/skills/chat-qwen/SKILL.md
+++ b/agents/openclaw/plugin/skills/chat-qwen/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: chat-qwen
+description: Chat with qwen3-30b-a3b-fp8, a 30.5B MoE model with strong multilingual coverage (100+ languages, 32K context). Use for non-English prompts, translation-adjacent tasks, or mid-weight questions the 1.2B edge models handle poorly.
+argument-hint: "<text>"
+allowed-tools: Bash(node -e *)
+metadata:
+  openclaw:
+    requires:
+      bins: [zerogpu, node]
+    install:
+      - kind: node
+        package: zerogpu-cli
+        bins: [zerogpu]
+---
+
+> **Sends your input to ZeroGPU's hosted API** for inference — this is not local processing. Don't pass secrets, credentials, or regulated data you aren't cleared to share with a third party. See the plugin README's "Data & privacy" section.
+
+Call qwen3-30b-a3b-fp8. `$ARGUMENTS` is the raw prompt — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+export ZGPU_TEXT
+node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}fetch("https://api.zerogpu.ai/v1/chat/completions",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"qwen3-30b-a3b-fp8",messages:[{role:"user",content:process.env.ZGPU_TEXT}]})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const c=d.choices&&d.choices[0]&&d.choices[0].message&&d.choices[0].message.content;console.log(c?c.trim():JSON.stringify(d,null,2))}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+```
+
+This model is served on Chat Completions only — the Responses endpoint is not available for it. Output is the assistant's answer as plain text; the model's separate reasoning field is deliberately dropped. Relay the answer as-is — do not rewrite or expand it.
+
+This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in the `cost-savings` skill.

--- a/agents/openclaw/plugin/skills/chat-qwen/SKILL.md
+++ b/agents/openclaw/plugin/skills/chat-qwen/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: chat-qwen
 description: Chat with qwen3-30b-a3b-fp8, a 30.5B MoE model with strong multilingual coverage (100+ languages, 32K context). Use for non-English prompts, translation-adjacent tasks, or mid-weight questions the 1.2B edge models handle poorly.
-argument-hint: "<text>"
-allowed-tools: Bash(node -e *)
+argument-hint: "<text> [-i <instructions>]"
+allowed-tools: Bash(zerogpu chat *)
 metadata:
   openclaw:
     requires:
-      bins: [zerogpu, node]
+      bins: [zerogpu]
     install:
       - kind: node
         package: zerogpu-cli
@@ -22,10 +22,11 @@ ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
 $ARGUMENTS
 ZGPU_END_OF_INPUT
 )
-export ZGPU_TEXT
-node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}fetch("https://api.zerogpu.ai/v1/chat/completions",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"qwen3-30b-a3b-fp8",messages:[{role:"user",content:process.env.ZGPU_TEXT}]})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const c=d.choices&&d.choices[0]&&d.choices[0].message&&d.choices[0].message.content;console.log(c?c.trim():JSON.stringify(d,null,2))}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+zerogpu chat "$ZGPU_TEXT" -m qwen3-30b-a3b-fp8
 ```
 
-This model is served on Chat Completions only — the Responses endpoint is not available for it. Output is the assistant's answer as plain text; the model's separate reasoning field is deliberately dropped. Relay the answer as-is — do not rewrite or expand it.
+If the user supplied system instructions, append `-i "<instructions>"` after the model flag.
 
-This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in the `cost-savings` skill.
+This model is served by the Chat Completions API rather than the Responses API; the CLI routes it automatically. Output is the assistant's answer as plain text — the model's reasoning trace is omitted, since this skill does not pass the CLI's `-r` flag. Relay the answer as-is — do not rewrite or expand it.
+
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest the `cost-savings` skill — this note is intentionally occasional, not shown every time.

--- a/agents/openclaw/plugin/skills/classify-domain/SKILL.md
+++ b/agents/openclaw/plugin/skills/classify-domain/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: classify-domain
 description: Classify a domain name against the IAB taxonomy without fetching the page (zlm-v1-iab-domain-classifier). Use when the user has a hostname or URL rather than article text — bidstream enrichment, allow/deny-list scoring, "what is example.com about?".
-argument-hint: "<domain-or-url>"
-allowed-tools: Bash(node -e *)
+argument-hint: "<domain>"
+allowed-tools: Bash(zerogpu classify_domain*)
 metadata:
   openclaw:
     requires:
-      bins: [zerogpu, node]
+      bins: [zerogpu]
     install:
       - kind: node
         package: zerogpu-cli
@@ -15,19 +15,16 @@ metadata:
 
 > **Sends your input to ZeroGPU's hosted API** for inference — this is not local processing. Don't pass secrets, credentials, or regulated data you aren't cleared to share with a third party. See the plugin README's "Data & privacy" section.
 
-Classify a domain. `$ARGUMENTS` is the domain or URL — pass it verbatim. Full URLs are normalized down to the hostname, so `https://www.nytimes.com/section/world?x=1` works as well as `nytimes.com`:
+Classify a domain:
 
 ```!
-ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
-$ARGUMENTS
-ZGPU_END_OF_INPUT
-)
-export ZGPU_TEXT
-node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}const dom=(process.env.ZGPU_TEXT||"").trim().replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//,"").split(/[\/?#]/)[0].toLowerCase();if(!dom){console.error("No domain supplied.");process.exit(1)}fetch("https://api.zerogpu.ai/v1/responses",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"zlm-v1-iab-domain-classifier",input:dom})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const m=(d.output||[]).find(o=>o.type==="message");const t=m&&(m.content||[]).find(c=>c.type==="output_text");if(!t){console.log(JSON.stringify(d,null,2));return}try{console.log(JSON.stringify(JSON.parse(t.text),null,2))}catch(e){console.log(t.text)}}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+zerogpu classify_domain "$ARGUMENTS"
 ```
+
+**Format `$ARGUMENTS` as a bare hostname.** The model takes only the domain — strip the scheme, path, query, and fragment first. `https://www.nytimes.com/section/world?x=1` becomes `www.nytimes.com`. If the user gave you several domains, run the command once per domain.
 
 Output is a JSON object with `audience` (IAB 2.2 audience tiers with scores) and `content` (`iab_1_0` and `iab_2_2` category lists).
 
-Use this instead of the `classify-iab` skill when the input is a domain — it needs only the hostname, so payloads are up to 10x smaller than sending page text. If the user has actual article text, use `classify-iab` or `classify-iab-enriched`.
+Use this instead of the `classify-iab` skill when the input is a domain — it needs only the hostname, so payloads are up to 10x smaller than sending page text. If the user has the actual article text and wants per-URL precision, use `classify-iab` or `classify-iab-enriched`.
 
-This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in the `cost-savings` skill.
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest the `cost-savings` skill — this note is intentionally occasional, not shown every time.

--- a/agents/openclaw/plugin/skills/classify-domain/SKILL.md
+++ b/agents/openclaw/plugin/skills/classify-domain/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: classify-domain
+description: Classify a domain name against the IAB taxonomy without fetching the page (zlm-v1-iab-domain-classifier). Use when the user has a hostname or URL rather than article text — bidstream enrichment, allow/deny-list scoring, "what is example.com about?".
+argument-hint: "<domain-or-url>"
+allowed-tools: Bash(node -e *)
+metadata:
+  openclaw:
+    requires:
+      bins: [zerogpu, node]
+    install:
+      - kind: node
+        package: zerogpu-cli
+        bins: [zerogpu]
+---
+
+> **Sends your input to ZeroGPU's hosted API** for inference — this is not local processing. Don't pass secrets, credentials, or regulated data you aren't cleared to share with a third party. See the plugin README's "Data & privacy" section.
+
+Classify a domain. `$ARGUMENTS` is the domain or URL — pass it verbatim. Full URLs are normalized down to the hostname, so `https://www.nytimes.com/section/world?x=1` works as well as `nytimes.com`:
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+export ZGPU_TEXT
+node -e 'const fs=require("fs"),os=require("os"),path=require("path");let key=process.env.ZEROGPU_API_KEY;try{key=JSON.parse(fs.readFileSync(path.join(os.homedir(),".zerogpu","config.json"),"utf8")).apiKey||key}catch(e){}if(!key){console.error("Not signed in to ZeroGPU. Run: zerogpu login");process.exit(1)}const dom=(process.env.ZGPU_TEXT||"").trim().replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//,"").split(/[\/?#]/)[0].toLowerCase();if(!dom){console.error("No domain supplied.");process.exit(1)}fetch("https://api.zerogpu.ai/v1/responses",{method:"POST",headers:{"content-type":"application/json","x-api-key":key},body:JSON.stringify({model:"zlm-v1-iab-domain-classifier",input:dom})}).then(async r=>{if(!r.ok){console.error("Request failed with status "+r.status+".");console.error(await r.text());process.exit(1)}return r.json()}).then(d=>{const m=(d.output||[]).find(o=>o.type==="message");const t=m&&(m.content||[]).find(c=>c.type==="output_text");if(!t){console.log(JSON.stringify(d,null,2));return}try{console.log(JSON.stringify(JSON.parse(t.text),null,2))}catch(e){console.log(t.text)}}).catch(e=>{console.error("Request failed: "+e.message);process.exit(1)})'
+```
+
+Output is a JSON object with `audience` (IAB 2.2 audience tiers with scores) and `content` (`iab_1_0` and `iab_2_2` category lists).
+
+Use this instead of the `classify-iab` skill when the input is a domain — it needs only the hostname, so payloads are up to 10x smaller than sending page text. If the user has actual article text, use `classify-iab` or `classify-iab-enriched`.
+
+This skill calls the ZeroGPU API directly rather than through the `zerogpu` CLI, which has no command for this model. It still uses the credentials `zerogpu login` saved, but its usage is **not** recorded in the `cost-savings` skill.

--- a/agents/openclaw/plugin/skills/generate-followups/SKILL.md
+++ b/agents/openclaw/plugin/skills/generate-followups/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: generate-followups
+description: Generate natural follow-up questions a reader would ask next about a passage (zlm-v1-followup-questions-edge). Use when the user wants suggested next questions, "people also ask" style prompts, or conversation continuations for an article, answer, or chat turn.
+argument-hint: "<text>"
+allowed-tools: Bash(zerogpu generate_followups*)
+metadata:
+  openclaw:
+    requires:
+      bins: [zerogpu]
+    install:
+      - kind: node
+        package: zerogpu-cli
+        bins: [zerogpu]
+---
+
+> **Sends your input to ZeroGPU's hosted API** for inference — this is not local processing. Don't pass secrets, credentials, or regulated data you aren't cleared to share with a third party. See the plugin README's "Data & privacy" section.
+
+Generate follow-up questions. `$ARGUMENTS` is the raw source text — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+zerogpu generate_followups "$ZGPU_TEXT"
+```
+
+Output is a JSON array of question strings. Relay them as-is — do not rewrite, reorder, or add your own questions.
+
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest the `cost-savings` skill — this note is intentionally occasional, not shown every time.


### PR DESCRIPTION
The [docs repo](https://github.com/zerogpu/docs) added three models and renamed a fourth, and `zerogpu-cli` 3.3.0 shipped the commands to reach them. The router covered none of it. This brings both plugins back in line, one skill per model.

## What the docs have that we didn't

| Model | Before | Now | Wraps |
|---|---|---|---|
| `zlm-v1-followup-questions-edge` | missing | `generate-followups` | `zerogpu generate_followups` |
| `zlm-v1-iab-domain-classifier` | missing | `classify-domain` | `zerogpu classify_domain` |
| `gpt-oss-120b` | missing | `chat-gpt-oss` | `zerogpu chat -m gpt-oss-120b` |
| `qwen3-30b-a3b-fp8` | missing | `chat-qwen` | `zerogpu chat -m qwen3-30b-a3b-fp8` |
| `zlm-v2-iab-classify-edge-enriched` | documented under the old `v1` id | renamed | unchanged |

Four skills, added identically to `agents/claude/skills/` and `agents/openclaw/plugin/skills/` — 14 skills → 18 in both plugins. Every one is a plain CLI wrapper, same shape as the existing 14.

## Changes

**`generate-followups`** — the questions a reader would ask next about a passage. The CLI has had this command since 3.1.0; the plugin never exposed it, though `marketplace.json` already advertised "follow-ups".

**`classify-domain`** — maps a bare hostname to the IAB taxonomy with no page fetch (~10x smaller payloads; built for bidstream enrichment and allow/deny-list scoring). Its own skill rather than a flag on `classify-iab`, because the input is a domain, not text. The skill instructs the agent to strip scheme/path/query, so pasting a full URL works.

**`chat-gpt-oss` / `chat-qwen`** — a skill each rather than exposing `chat`'s `--model` flag directly, so every skill stays pinned to one model and Claude can route on the description. `qwen3-30b-a3b-fp8` is served by Chat Completions rather than Responses; the CLI handles that internally.

**No reasoning passthrough.** Both new chat models return a reasoning trace. Neither skill passes the CLI's `-r` flag, so only the final answer prints — matching `chat`. `chat-thinking` stays the one skill that surfaces reasoning.

**Enriched rename** — `classify-iab-enriched` docs now say `zlm-v2-iab-classify-edge-enriched`, matching the catalog and the id CLI 3.3.0 sends. No behavior change.

**Savings tracking is intact.** All four route through the CLI, and 3.3.0 prices every one of these models in its savings table, so they contribute to `cost-savings` like any other skill.

## Requires `zerogpu-cli` ≥ 3.3.0

`chat --model` and `classify_domain` landed in 3.3.0, so the three new model skills need it. The other 15 work on any 3.x. Noted in both READMEs and both changelogs; the Claude README prerequisites table now pins the floor.

## Verification

Every command was run exactly as written in the SKILL.md files, against the live API on CLI 3.3.0:

- `chat-gpt-oss` and `chat-qwen` → correct answers, reasoning trace absent (no `-r`), including a Spanish prompt through `chat-qwen`
- `classify-domain` → `www.nytimes.com` returned News and Politics categories
- `generate-followups` → JSON array of questions
- heredoc quoting → multi-line input containing quotes, `$HOME`, backticks and parens reached the model verbatim, no shell expansion
- 💰 savings line appears on routed calls, confirming these models register in `cost-savings`

CI equivalents, all green locally:

- `claude plugin validate .` and `claude plugin validate ./agents/claude` — passed
- `npm run build` in `agents/openclaw/plugin` — clean
- `npm pack --dry-run` — 18 skills in the tarball
- manifest/disk parity — `openclaw.plugin.json` lists 18 skills, matching both skill directories exactly

Versions untouched in `plugin.json` / `package.json` per both release guides; changelogs carry `## 1.6.0` (Claude) and `## 3.1.0` (OpenClaw) for the release scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)