### PR TITLE
Add chat-glm and chat-deepseek skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "zerogpu-router",
       "source": "./agents/claude",
-      "description": "Route classification, domain classification, summarization, entity/PII/JSON extraction, follow-ups, and small- to mid-model chat to ZeroGPU — 18 auto-invoked skills.",
+      "description": "Route classification, domain classification, summarization, entity/PII/JSON extraction, follow-ups, and small- to mid-model chat to ZeroGPU — 20 auto-invoked skills.",
       "category": "productivity",
       "tags": ["nlp", "classification", "summarization", "extraction", "pii", "ner", "cost-optimization", "small-models"]
     }

--- a/README.md
+++ b/README.md
@@ -132,23 +132,43 @@ Full walkthrough (prerequisites, every skill documented in detail, troubleshooti
 
 ## Routes
 
-ZeroGPU Router exposes eleven task-specific routes:
+ZeroGPU Router exposes twenty auto-invoked skills: seventeen task routes and three account utilities.
 
-| Route | Workload | Model |
+**Chat and generation**
+
+| Skill | Workload | Model |
 |---|---|---|
-| `zerogpu_classify_iab` | IAB topic classification | `zlm-v1-iab-classify-edge` |
-| `zerogpu_classify_iab_enriched` | IAB categories plus topics, keywords, intent | `zlm-v1-iab-classify-edge-enriched` |
-| `zerogpu_summarize` | TL;DRs, abstracts, meeting note summaries | `llama-3.1-8b-instruct-fast` |
-| `zerogpu_classify_zero_shot` | Classify against a flat label list | `deberta-v3-small` |
-| `zerogpu_classify_structured` | Multi-axis schema classification | `gliner2-base-v1` |
-| `zerogpu_extract_entities` | Extract people, places, companies, dates, custom entities | `gliner2-base-v1` |
-| `zerogpu_extract_json` | Pull structured fields into grouped JSON | `gliner2-base-v1` |
-| `zerogpu_redact_pii` | Mask emails, phones, names, addresses, other PII | `gliner-multi-pii-v1` |
-| `zerogpu_extract_pii` | Extract PII grouped by category | `gliner-multi-pii-v1` |
-| `zerogpu_chat` | Short small-model chat replies | `LFM2.5-1.2B-Instruct` |
-| `zerogpu_chat_thinking` | Short chat replies with a visible reasoning trace | `LFM2.5-1.2B-Thinking` |
+| `chat` | Default chat: long context, multi-step instructions | `gpt-oss-120b` |
+| `chat-liquid` | Fastest, cheapest chat replies | `LFM2.5-1.2B-Instruct` |
+| `chat-thinking` | Short chat replies with a visible reasoning trace | `LFM2.5-1.2B-Thinking` |
+| `chat-qwen` | Multilingual chat, 100+ languages | `qwen3-30b-a3b-fp8` |
+| `chat-deepseek` | Coding and agentic work, 1M-token context | `deepseek-v4-flash` |
+| `chat-glm` | Largest and most capable, 1M-token context, ~20x the cost | `glm-5.2` |
+| `summarize` | TL;DRs, abstracts, meeting note summaries | `llama-3.1-8b-instruct-fast` |
+| `generate-followups` | Suggested next questions for a passage | `zlm-v1-followup-questions-edge` |
 
-Every route returns `{ <task fields>, model, usage, savings }`.
+**Classification**
+
+| Skill | Workload | Model |
+|---|---|---|
+| `classify-iab` | IAB topic classification | `zlm-v1-iab-classify-edge` |
+| `classify-iab-enriched` | IAB categories plus topics, keywords, intent | `zlm-v2-iab-classify-edge-enriched` |
+| `classify-domain` | IAB classification from a bare hostname, no page fetch | `zlm-v1-iab-domain-classifier` |
+| `classify-zero-shot` | Classify against a flat label list | `deberta-v3-small` |
+| `classify-structured` | Multi-axis schema classification | `gliner2-base-v1` |
+
+**Extraction and PII**
+
+| Skill | Workload | Model |
+|---|---|---|
+| `extract-entities` | Extract people, places, companies, dates, custom entities | `gliner2-base-v1` |
+| `extract-json` | Pull structured fields into grouped JSON | `gliner2-base-v1` |
+| `extract-pii` | Extract PII grouped by category | `gliner-multi-pii-v1` |
+| `redact-pii` | Mask emails, phones, names, addresses, other PII | `gliner-multi-pii-v1` |
+
+**Account** (manual only): `signin`, `status`, `cost-savings`.
+
+Every task skill prints the model's answer as plain text, and occasionally appends a `💰 ZeroGPU savings` line.
 
 ## Packages
 

--- a/agents/claude/CHANGELOG.md
+++ b/agents/claude/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2.1.0
+
+Two skills for the open-weight models the docs catalog gained, both with a 1,048,576-token context window. Skill count goes from 18 to 20.
+
+The reason to care about either is size: `chat` tops out at a 131,072-token context, and until now nothing here went past it.
+
+### Added
+
+- **`chat-glm`** wraps `zerogpu chat -m glm-5.2`. A 753B MoE flagship (8 of 256 experts per token) with a 1M-token context, for whole repositories, book-length documents, and long agent transcripts. It is the most capable model on the platform and the most expensive by a wide margin: \$1.10 / \$3.50 per 1M input/output tokens, against \$0.03 / \$0.10 for `chat` and \$0.02 / \$0.05 for the edge models. That is roughly 20x `chat` and over 50x `chat-liquid`, so this is the one skill where the usual savings framing does not hold. Its description says so explicitly, to keep Claude from picking it for prompts that `chat` would handle.
+- **`chat-deepseek`** wraps `zerogpu chat -m deepseek-v4-flash`. A 284B MoE model (13B active per token) with the same 1M context, tuned for coding and agentic workflows, at \$0.07 / \$0.14 per 1M. Roughly a sixteenth of `chat-glm`, so it is the better default whenever the task is code or tool-use rather than sheer input size.
+
+Both models are served by the Chat Completions API rather than the Responses API; the CLI routes them automatically.
+
+### Changed
+
+- **`chat` now points at the new skills.** Its "for X use Y" line previously stopped at `chat-qwen`; it now also names `chat-deepseek` and `chat-glm` for input that exceeds its 131K context.
+- **The root README's routes table was rewritten.** It had drifted badly: it claimed eleven routes, used the retired MCP-era `zerogpu_*` tool names rather than skill names, listed `zerogpu_chat` as `LFM2.5-1.2B-Instruct` (the default moved to `gpt-oss-120b` in 2.0.0), still showed the old `zlm-v1` enriched IAB id, and omitted `classify-domain`, `generate-followups`, `chat-liquid`, and `chat-qwen` entirely.
+
+### Known issues
+
+- **`chat-deepseek` does not work yet.** `deepseek-v4-flash` is published in the ZeroGPU API reference but not yet served: the API returns `404 model_not_found` for it. The skill is correct per the published spec and will start working the moment the platform enables the model, with no further change here. `chat-glm` was verified working end to end.
+
+### Requires
+
+- `zerogpu-cli` >= 3.4.0, the release that added `glm-5.2` and `deepseek-v4-flash` to the `chat --model` allowlist. Earlier versions reject both with `Unknown model` before any request is made.
+
 ## 2.0.0
 
 `chat` now runs on **`gpt-oss-120b`** instead of `LFM2.5-1.2B-Instruct`. The old edge-model behavior moves to a new `chat-liquid` skill, and `chat-gpt-oss` is removed because `chat` now covers it. Skill count stays at 18.

--- a/agents/claude/README.md
+++ b/agents/claude/README.md
@@ -14,7 +14,7 @@ Every command in the `zerogpu` CLI is exposed as a Claude Code skill. Claude aut
 | --- | --- | --- |
 | **Node.js ≥ 20** | Runs the `zerogpu` CLI | [nodejs.org](https://nodejs.org) |
 | **Claude Code** | Hosts the plugin | `npm install -g @anthropic-ai/claude-code` |
-| **`zerogpu` CLI ≥ 3.3.0** | Skills shell out to it | `npm install -g zerogpu-cli@latest` |
+| **`zerogpu` CLI ≥ 3.4.0** | Skills shell out to it | `npm install -g zerogpu-cli@latest` |
 | **ZeroGPU account** | API key | [zerogpu.ai](https://zerogpu.ai) |
 
 Verify the CLI is on your `PATH` and current:
@@ -23,7 +23,7 @@ Verify the CLI is on your `PATH` and current:
 zerogpu --version
 ```
 
-The chat skills and `classify-domain` need **3.3.0 or newer**. That release added `chat --model` and the `classify_domain` command. On an older CLI those skills fail.
+Most chat skills and `classify-domain` need **3.3.0 or newer**, the release that added `chat --model` and the `classify_domain` command. `chat-glm` and `chat-deepseek` need **3.4.0 or newer**, which added those two models to the CLI's `--model` allowlist — on an older CLI they fail with `Unknown model` before any request is made.
 
 ### 1. Authenticate the CLI
 
@@ -235,7 +235,7 @@ The default ZeroGPU chat skill. Handles work the 1.2B edge models can't carry (l
 
 **Output:** the assistant's answer as plain text. The model emits a reasoning trace as well; the skill leaves off the CLI's `-r` flag, so only the final answer is printed.
 
-Reach for `chat-liquid` when speed and cost matter more than quality, `chat-thinking` for a visible reasoning trace, or `chat-qwen` for multilingual prompts.
+Reach for `chat-liquid` when speed and cost matter more than quality, `chat-thinking` for a visible reasoning trace, or `chat-qwen` for multilingual prompts. When the input exceeds this model's 131K context, use `chat-deepseek` for code and agentic work or `chat-glm` for the most capable option — both carry a 1M-token context.
 
 ---
 
@@ -313,6 +313,58 @@ Heavier chat tuned for multilingual work: 100+ languages, useful when the prompt
 ```
 
 **Output:** the assistant's answer as plain text. This model is served by the Chat Completions API rather than the Responses API; the CLI routes it automatically. Its reasoning trace is omitted, since the skill doesn't pass `-r`.
+
+---
+
+### `/zerogpu-router:chat-deepseek`
+
+Coding and agentic chat with a 1M-token context: reading or writing code across a large codebase, porting and refactoring, planning multi-step automation.
+
+- **Model:** `deepseek-v4-flash` (284B MoE, 13B active per token, 1,048,576-token context)
+- **Wraps:** `zerogpu chat -m deepseek-v4-flash`
+- **When Claude auto-invokes:** code-heavy prompts, repo-scale questions, multi-step tool-use planning — especially when the input is too large for `chat`'s 131K context.
+
+**Synopsis**
+
+```
+/zerogpu-router:chat-deepseek <text> [-i <instructions>]
+```
+
+**Example**
+
+```text
+/zerogpu-router:chat-deepseek "Port this callback-based module to async/await and flag any behaviour changes."
+```
+
+**Output:** the assistant's answer as plain text. Chat Completions only; the CLI routes it automatically. Its reasoning trace is omitted, since the skill doesn't pass `-r`.
+
+At \$0.07 / \$0.14 per 1M input/output tokens this is the cheaper of the two 1M-context models — about a sixteenth of `chat-glm`. Prefer it when the task is code or tool-use rather than sheer input size.
+
+---
+
+### `/zerogpu-router:chat-glm`
+
+The largest and most capable model on the platform, with a 1M-token context for whole repositories, book-length documents, and long agent transcripts.
+
+- **Model:** `glm-5.2` (753B MoE, 8 of 256 experts per token, 1,048,576-token context)
+- **Wraps:** `zerogpu chat -m glm-5.2`
+- **When Claude auto-invokes:** long-horizon reasoning, or input that genuinely does not fit anywhere else.
+
+**Synopsis**
+
+```
+/zerogpu-router:chat-glm <text> [-i <instructions>]
+```
+
+**Example**
+
+```text
+/zerogpu-router:chat-glm "Here is our entire service directory. Which services would a payments outage take down, and in what order?"
+```
+
+**Output:** the assistant's answer as plain text. Chat Completions only; the CLI routes it automatically. Its reasoning trace is omitted, since the skill doesn't pass `-r`.
+
+**Cost:** \$1.10 / \$3.50 per 1M input/output tokens — roughly 20x `chat` (`gpt-oss-120b`) and over 50x the 1.2B edge models. It is the one skill here where the usual savings framing does not apply, so reach for it only when the size or horizon of the task actually requires it.
 
 ---
 
@@ -712,7 +764,7 @@ Generate the questions a reader would naturally ask next about a passage: "peopl
 
 ## Skills reference
 
-Quick lookup table: all 18 skills at a glance.
+Quick lookup table: all 20 skills at a glance.
 
 | Skill | Purpose | Example |
 | --- | --- | --- |
@@ -723,6 +775,8 @@ Quick lookup table: all 18 skills at a glance.
 | `/zerogpu-router:chat-liquid <text>` | Fastest, cheapest chat via `LFM2.5-1.2B-Instruct` | `/zerogpu-router:chat-liquid "Explain WebSockets in two sentences."` |
 | `/zerogpu-router:chat-thinking <text>` | Chat with the Thinking variant (returns reasoning) | `/zerogpu-router:chat-thinking "If a train leaves at 3 PM going 60 mph, when does it cover 150 miles?"` |
 | `/zerogpu-router:chat-qwen <text>` | Heavier multilingual chat via `qwen3-30b-a3b-fp8` | `/zerogpu-router:chat-qwen "Explica los índices B-tree en dos frases."` |
+| `/zerogpu-router:chat-deepseek <text>` | Coding and agentic chat via `deepseek-v4-flash` (1M context) | `/zerogpu-router:chat-deepseek "Port this module to async/await."` |
+| `/zerogpu-router:chat-glm <text>` | Most capable, 1M context via `glm-5.2` (~20x the cost) | `/zerogpu-router:chat-glm "Which services would a payments outage take down?"` |
 | `/zerogpu-router:classify-iab <text>` | IAB taxonomy classification | `/zerogpu-router:classify-iab "The Lakers signed a new point guard."` |
 | `/zerogpu-router:classify-iab-enriched <text>` | IAB + topics/keywords/intent | `/zerogpu-router:classify-iab-enriched "Compare the Tesla Model Y and Hyundai Ioniq 5."` |
 | `/zerogpu-router:classify-domain <domain>` | IAB classification from a hostname, no page fetch | `/zerogpu-router:classify-domain "espn.com"` |

--- a/agents/claude/skills/chat-deepseek/SKILL.md
+++ b/agents/claude/skills/chat-deepseek/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: chat-deepseek
+description: Chat with deepseek-v4-flash, a 284B MoE model (13B active per token) with a 1M-token context window, tuned for coding and agentic workflows. Use for reading or writing code across a large codebase, porting and refactoring, or planning multi-step automation. Cheaper than chat-glm at the same context size.
+argument-hint: "<text> [-i <instructions>]"
+allowed-tools: Bash(zerogpu chat *)
+---
+
+Call deepseek-v4-flash. `$ARGUMENTS` is the raw prompt — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+zerogpu chat "$ZGPU_TEXT" -m deepseek-v4-flash
+```
+
+If the user supplied system instructions, append `-i "<instructions>"` after the model flag.
+
+At \$0.07 / \$0.14 per 1M input/output tokens this is the cheaper of the two 1M-context models — roughly a sixteenth of `/zerogpu-router:chat-glm`. Prefer it whenever the task is code or tool-use rather than sheer input size. For a prompt that fits in 131K tokens, `/zerogpu-router:chat` is cheaper still.
+
+This model is served by the Chat Completions API rather than the Responses API; the CLI routes it automatically. Output is the assistant's answer as plain text — the model's reasoning trace is omitted, since this skill does not pass the CLI's `-r` flag. Relay the answer as-is — do not rewrite or expand it.
+
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest `/zerogpu-router:cost-savings` — this note is intentionally occasional, not shown every time.

--- a/agents/claude/skills/chat-glm/SKILL.md
+++ b/agents/claude/skills/chat-glm/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: chat-glm
+description: Chat with glm-5.2, a 753B MoE flagship with a 1M-token context window. Use when the input is too large for the other chat skills — an entire repository, a book-length document, a long agent transcript — or for long-horizon reasoning the smaller models cannot hold together. This is the most expensive model on the platform by roughly 20x, so prefer chat for anything that fits in its 131K context.
+argument-hint: "<text> [-i <instructions>]"
+allowed-tools: Bash(zerogpu chat *)
+---
+
+Call glm-5.2. `$ARGUMENTS` is the raw prompt — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+zerogpu chat "$ZGPU_TEXT" -m glm-5.2
+```
+
+If the user supplied system instructions, append `-i "<instructions>"` after the model flag.
+
+Reach for this only when the size or horizon of the task actually needs it. At \$1.10 / \$3.50 per 1M input/output tokens, glm-5.2 costs about twenty times `/zerogpu-router:chat` (`gpt-oss-120b`, \$0.03 / \$0.10) and over fifty times the 1.2B edge models. For a prompt that fits in 131K tokens, `/zerogpu-router:chat` is the right call. For coding and agentic work at the same 1M context, `/zerogpu-router:chat-deepseek` is far cheaper.
+
+This model is served by the Chat Completions API rather than the Responses API; the CLI routes it automatically. Output is the assistant's answer as plain text — the model's reasoning trace is omitted, since this skill does not pass the CLI's `-r` flag. Relay the answer as-is — do not rewrite or expand it.
+
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest `/zerogpu-router:cost-savings` — this note is intentionally occasional, not shown every time.

--- a/agents/claude/skills/chat/SKILL.md
+++ b/agents/claude/skills/chat/SKILL.md
@@ -19,6 +19,6 @@ If the user supplied system instructions, append `-i "<instructions>"` after the
 
 Output is the assistant's answer as plain text. The model also produces a reasoning trace; this skill omits the CLI's `-r` flag so only the final answer is printed. Relay that answer as-is, without rewriting or expanding it.
 
-For a faster, cheaper reply where quality matters less, use `/zerogpu-router:chat-liquid` (LFM2.5-1.2B-Instruct). For a visible reasoning trace, use `/zerogpu-router:chat-thinking`. For multilingual prompts, use `/zerogpu-router:chat-qwen`.
+For a faster, cheaper reply where quality matters less, use `/zerogpu-router:chat-liquid` (LFM2.5-1.2B-Instruct). For a visible reasoning trace, use `/zerogpu-router:chat-thinking`. For multilingual prompts, use `/zerogpu-router:chat-qwen`. When the input does not fit in this model's 131K context, use `/zerogpu-router:chat-deepseek` for code and agentic work, or `/zerogpu-router:chat-glm` for the largest and most capable option — both carry a 1M-token context, and glm-5.2 costs roughly 20x this skill.
 
 Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest `/zerogpu-router:cost-savings`. This note is intentionally occasional, not shown every time.

--- a/agents/openclaw/CHANGELOG.md
+++ b/agents/openclaw/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 4.1.0
+
+Two skills for the open-weight models the docs catalog gained, both with a 1,048,576-token context window. Skill count goes from 18 to 20.
+
+The reason to care about either is size: `chat` tops out at a 131,072-token context, and until now nothing here went past it.
+
+### Added
+
+- **`chat-glm`** wraps `zerogpu chat -m glm-5.2`. A 753B MoE flagship (8 of 256 experts per token) with a 1M-token context, for whole repositories, book-length documents, and long agent transcripts. It is the most capable model on the platform and the most expensive by a wide margin: \$1.10 / \$3.50 per 1M input/output tokens, against \$0.03 / \$0.10 for `chat` and \$0.02 / \$0.05 for the edge models. That is roughly 20x `chat` and over 50x `chat-liquid`, so this is the one skill where the usual savings framing does not hold. Its description says so explicitly, to keep the host model from picking it for prompts that `chat` would handle.
+- **`chat-deepseek`** wraps `zerogpu chat -m deepseek-v4-flash`. A 284B MoE model (13B active per token) with the same 1M context, tuned for coding and agentic workflows, at \$0.07 / \$0.14 per 1M. Roughly a sixteenth of `chat-glm`, so it is the better default whenever the task is code or tool-use rather than sheer input size.
+
+Both models are served by the Chat Completions API rather than the Responses API; the CLI routes them automatically.
+
+### Changed
+
+- **`chat` now points at the new skills.** Its "for X use Y" line previously stopped at `chat-qwen`; it now also names `chat-deepseek` and `chat-glm` for input that exceeds its 131K context.
+- **The root README's routes table was rewritten.** It had drifted badly: it claimed eleven routes, used the retired MCP-era `zerogpu_*` tool names rather than skill names, listed `zerogpu_chat` as `LFM2.5-1.2B-Instruct` (the default moved to `gpt-oss-120b` in 4.0.0), still showed the old `zlm-v1` enriched IAB id, and omitted `classify-domain`, `generate-followups`, `chat-liquid`, and `chat-qwen` entirely.
+
+### Known issues
+
+- **`chat-deepseek` does not work yet.** `deepseek-v4-flash` is published in the ZeroGPU API reference but not yet served: the API returns `404 model_not_found` for it. The skill is correct per the published spec and will start working the moment the platform enables the model, with no further change here. `chat-glm` was verified working end to end.
+
+### Requires
+
+- `zerogpu-cli` >= 3.4.0, the release that added `glm-5.2` and `deepseek-v4-flash` to the `chat --model` allowlist. Earlier versions reject both with `Unknown model` before any request is made. Run `npm install -g zerogpu-cli@latest` before upgrading this plugin.
+
 ## 4.0.0
 
 `chat` now runs on **`gpt-oss-120b`** instead of `LFM2.5-1.2B-Instruct`. The old edge-model behavior moves to a new `chat-liquid` skill, and `chat-gpt-oss` is removed because `chat` now covers it. Skill count stays at 18.

--- a/agents/openclaw/plugin/README.md
+++ b/agents/openclaw/plugin/README.md
@@ -147,6 +147,8 @@ Note the card last-four is left untouched. The PII model covers standard categor
 | `chat-liquid` | Fastest, cheapest chat replies | `LFM2.5-1.2B-Instruct` |
 | `chat-thinking` | Short chat replies with a visible reasoning trace | `LFM2.5-1.2B-Thinking` |
 | `chat-qwen` | Multilingual chat, 100+ languages | `qwen3-30b-a3b-fp8` |
+| `chat-deepseek` | Coding and agentic work, 1M-token context | `deepseek-v4-flash` |
+| `chat-glm` | Largest context and most capable, ~20x the cost | `glm-5.2` |
 
 **Account**
 

--- a/agents/openclaw/plugin/openclaw.plugin.json
+++ b/agents/openclaw/plugin/openclaw.plugin.json
@@ -6,6 +6,8 @@
   "version": "4.0.0",
   "skills": [
     "./skills/chat",
+    "./skills/chat-deepseek",
+    "./skills/chat-glm",
     "./skills/chat-liquid",
     "./skills/chat-qwen",
     "./skills/chat-thinking",

--- a/agents/openclaw/plugin/skills/chat-deepseek/SKILL.md
+++ b/agents/openclaw/plugin/skills/chat-deepseek/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: chat-deepseek
+description: Chat with deepseek-v4-flash, a 284B MoE model (13B active per token) with a 1M-token context window, tuned for coding and agentic workflows. Use for reading or writing code across a large codebase, porting and refactoring, or planning multi-step automation. Cheaper than chat-glm at the same context size.
+argument-hint: "<text> [-i <instructions>]"
+allowed-tools: Bash(zerogpu chat *)
+metadata:
+  openclaw:
+    requires:
+      bins: [zerogpu]
+    install:
+      - kind: node
+        package: zerogpu-cli
+        bins: [zerogpu]
+---
+
+> **Sends your input to ZeroGPU's hosted API** for inference — this is not local processing. Don't pass secrets, credentials, or regulated data you aren't cleared to share with a third party. See the plugin README's "Data & privacy" section.
+
+Call deepseek-v4-flash. `$ARGUMENTS` is the raw prompt — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+zerogpu chat "$ZGPU_TEXT" -m deepseek-v4-flash
+```
+
+If the user supplied system instructions, append `-i "<instructions>"` after the model flag.
+
+At \$0.07 / \$0.14 per 1M input/output tokens this is the cheaper of the two 1M-context models — roughly a sixteenth of `chat-glm`. Prefer it whenever the task is code or tool-use rather than sheer input size. For a prompt that fits in 131K tokens, `chat` is cheaper still.
+
+This model is served by the Chat Completions API rather than the Responses API; the CLI routes it automatically. Output is the assistant's answer as plain text — the model's reasoning trace is omitted, since this skill does not pass the CLI's `-r` flag. Relay the answer as-is — do not rewrite or expand it.
+
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest the `cost-savings` skill — this note is intentionally occasional, not shown every time.

--- a/agents/openclaw/plugin/skills/chat-glm/SKILL.md
+++ b/agents/openclaw/plugin/skills/chat-glm/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: chat-glm
+description: Chat with glm-5.2, a 753B MoE flagship with a 1M-token context window. Use when the input is too large for the other chat skills — an entire repository, a book-length document, a long agent transcript — or for long-horizon reasoning the smaller models cannot hold together. This is the most expensive model on the platform by roughly 20x, so prefer chat for anything that fits in its 131K context.
+argument-hint: "<text> [-i <instructions>]"
+allowed-tools: Bash(zerogpu chat *)
+metadata:
+  openclaw:
+    requires:
+      bins: [zerogpu]
+    install:
+      - kind: node
+        package: zerogpu-cli
+        bins: [zerogpu]
+---
+
+> **Sends your input to ZeroGPU's hosted API** for inference — this is not local processing. Don't pass secrets, credentials, or regulated data you aren't cleared to share with a third party. See the plugin README's "Data & privacy" section.
+
+Call glm-5.2. `$ARGUMENTS` is the raw prompt — pass it verbatim, no escaping or quoting required (the heredoc below handles every shell metacharacter, newline, quote, and paren safely):
+
+```!
+ZGPU_TEXT=$(cat <<'ZGPU_END_OF_INPUT'
+$ARGUMENTS
+ZGPU_END_OF_INPUT
+)
+zerogpu chat "$ZGPU_TEXT" -m glm-5.2
+```
+
+If the user supplied system instructions, append `-i "<instructions>"` after the model flag.
+
+Reach for this only when the size or horizon of the task actually needs it. At \$1.10 / \$3.50 per 1M input/output tokens, glm-5.2 costs about twenty times `chat` (`gpt-oss-120b`, \$0.03 / \$0.10) and over fifty times the 1.2B edge models. For a prompt that fits in 131K tokens, `chat` is the right call. For coding and agentic work at the same 1M context, `chat-deepseek` is far cheaper.
+
+This model is served by the Chat Completions API rather than the Responses API; the CLI routes it automatically. Output is the assistant's answer as plain text — the model's reasoning trace is omitted, since this skill does not pass the CLI's `-r` flag. Relay the answer as-is — do not rewrite or expand it.
+
+Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest the `cost-savings` skill — this note is intentionally occasional, not shown every time.

--- a/agents/openclaw/plugin/skills/chat/SKILL.md
+++ b/agents/openclaw/plugin/skills/chat/SKILL.md
@@ -29,6 +29,6 @@ If the user supplied system instructions, append `-i "<instructions>"` after the
 
 Output is the assistant's answer as plain text. The model also produces a reasoning trace; this skill omits the CLI's `-r` flag so only the final answer is printed. Relay that answer as-is, without rewriting or expanding it.
 
-For a faster, cheaper reply where quality matters less, use the `chat-liquid` skill (LFM2.5-1.2B-Instruct). For a visible reasoning trace, use `chat-thinking`. For multilingual prompts, use `chat-qwen`.
+For a faster, cheaper reply where quality matters less, use the `chat-liquid` skill (LFM2.5-1.2B-Instruct). For a visible reasoning trace, use `chat-thinking`. For multilingual prompts, use `chat-qwen`. When the input does not fit in this model's 131K context, use `chat-deepseek` for code and agentic work, or `chat-glm` for the largest and most capable option — both carry a 1M-token context, and glm-5.2 costs roughly 20x this skill.
 
 Savings note: only if the command output literally contains a line starting with `💰 ZeroGPU savings`, append that exact line, unchanged, as the last line of your reply. If no such line is present, say nothing about savings and do not mention or suggest the `cost-savings` skill. This note is intentionally occasional, not shown every time.


### PR DESCRIPTION
## Summary

The docs catalog gained `glm-5.2` and `deepseek-v4-flash` in [docs#19](https://github.com/zerogpu/docs/pull/19), both with a 1,048,576-token context window. Two new skills, mirrored across the Claude and OpenClaw trees. **Skill count goes from 18 to 20.**

Size is the reason either matters: `chat` tops out at 131,072 tokens, and until now nothing here went past it.

| Skill | Model | Params | Context | $/1M in | $/1M out |
|---|---|---|---|---|---|
| `chat-glm` | `glm-5.2` | 753B MoE (8 of 256 experts) | 1,048,576 | $1.10 | $3.50 |
| `chat-deepseek` | `deepseek-v4-flash` | 284B MoE (13B active) | 1,048,576 | $0.07 | $0.14 |

Both follow `chat-qwen`, the existing Chat-Completions-only skill — same heredoc pattern, byte-identical command blocks between the two trees.

## The descriptions do the real work

`glm-5.2` costs roughly **20x `chat`** and over **50x `chat-liquid`**. Since the description is what the agent routes on, one that only said "most capable" would get it picked for prompts `chat` handles fine — on a plugin whose entire pitch is cost reduction. Both new descriptions state the cost relationship explicitly and name the cheaper skill to fall back to.

## Drive-by fix: the root README routes table

Approved as part of this change. It had drifted well past the two rows this PR needed:

- claimed **eleven** routes (there are 20 skills)
- used the retired **MCP-era `zerogpu_*` tool names** instead of skill names
- listed `zerogpu_chat` as `LFM2.5-1.2B-Instruct` — the default moved to `gpt-oss-120b` in 2.0.0 / 4.0.0
- still showed the old **`zlm-v1`** enriched IAB id
- omitted `classify-domain`, `generate-followups`, `chat-liquid`, `chat-qwen` entirely

Rewritten as grouped tables matching the plugin READMEs.

## ⚠️ Corrected CLI floor: 3.4.0, not 3.3.0

I initially wrote `>= 3.3.0` and it was wrong. Verified against the published npm tarballs:

- **`zerogpu-cli@3.3.0`** → does *not* carry these models; rejects them with `Unknown model` before any request
- **`zerogpu-cli@3.4.0`** → carries both ✅

Both changelogs and the Claude README prerequisites now say **3.4.0**. Worth noting the CLI allowlist is client-side, so an out-of-date CLI fails these skills without ever reaching the API.

## ⚠️ `chat-deepseek` does not work yet

Verified end to end on 3.4.0, running each skill's exact command:

- `zerogpu chat "…" -m glm-5.2` → returns an answer ✅
- `zerogpu chat "…" -m deepseek-v4-flash` → `404 model_not_found` ❌

`deepseek-v4-flash` is published in the API reference but not yet served. The skill is correct per the spec and will work once the platform enables it. Recorded under **Known issues** in both changelogs rather than shipped silently. The same gap appears in the CLI, MCP, and LangChain repos — worth checking whether the docs page landed ahead of the deployment.

## Testing

- `claude plugin validate .` and `claude plugin validate ./agents/claude` — both pass
- `npm ci && npm run build && npm pack --dry-run` in `agents/openclaw/plugin` — passes; both new `SKILL.md` files are in the pack; `skills[]` has 20 entries; `package.json` / `openclaw.plugin.json` versions still consistent
- `diff` on each claude/openclaw pair shows only the three expected mechanical differences (openclaw `metadata` block, privacy blockquote, bare vs `/zerogpu-router:` skill names) — command blocks byte-identical

Changelogs added at `## 2.1.0` (claude) and `## 4.1.0` (openclaw) per the CI gate. Manifest versions deliberately **not** hand-bumped — `scripts/claude-release` and `scripts/openclaw-release` own those, per the release guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `chat-glm` and `chat-deepseek` skills for large-context conversations, supporting inputs up to 1 million tokens.
  * Expanded chat routing guidance for long prompts, coding tasks, multilingual requests, and model selection.
  * Updated integrations to expose 20 auto-invoked skills.

* **Documentation**
  * Refreshed route listings, model guidance, installation requirements, and output behavior.
  * Documented the required `zerogpu-cli` version and noted the current availability issue for `chat-deepseek`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->